### PR TITLE
메모화면 풀스크린 적용

### DIFF
--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/base/BaseFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/base/BaseFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
-import com.nextroom.nextroom.presentation.extension.statusBarHeight
 import com.nextroom.nextroom.presentation.util.FragmentLifecycleLogger
 import com.nextroom.nextroom.presentation.util.FragmentLifecycleLoggerImpl
 
@@ -32,18 +31,6 @@ abstract class BaseFragment<VB : ViewBinding>(private val inflate: Inflate<VB>) 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         registerViewLifecycleOwner(this)
-    }
-
-    fun setMarginTopStatusBarHeight(view: View) {
-        (view.layoutParams as? ViewGroup.MarginLayoutParams)?.apply {
-            setMargins(
-                leftMargin,
-                topMargin + view.context.statusBarHeight,
-                rightMargin,
-                bottomMargin,
-            )
-        }
-        view.requestLayout()
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/extension/View.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/extension/View.kt
@@ -2,8 +2,10 @@ package com.nextroom.nextroom.presentation.extension
 
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.core.view.postDelayed
+import androidx.core.view.updateLayoutParams
 
 fun View.showKeyboard(): Boolean = run {
     requestFocus()
@@ -39,5 +41,11 @@ fun View.setOnLongClickListener(duration: Long = 2000L, action: () -> Unit) {
 
             else -> false
         }
+    }
+}
+
+fun View.addMargin(left: Int = 0, right: Int = 0, top: Int = 0, bottom: Int = 0) {
+    updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        setMargins(leftMargin + left, topMargin + top, rightMargin + right, bottomMargin + bottom)
     }
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
@@ -12,7 +12,9 @@ import com.nextroom.nextroom.presentation.R
 import com.nextroom.nextroom.presentation.base.BaseFragment
 import com.nextroom.nextroom.presentation.common.NRImageDialog
 import com.nextroom.nextroom.presentation.databinding.FragmentAdminMainBinding
+import com.nextroom.nextroom.presentation.extension.addMargin
 import com.nextroom.nextroom.presentation.extension.safeNavigate
+import com.nextroom.nextroom.presentation.extension.statusBarHeight
 import dagger.hilt.android.AndroidEntryPoint
 import org.orbitmvi.orbit.viewmodel.observe
 
@@ -56,7 +58,7 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
     }
 
     private fun initViews() = with(binding) {
-        setMarginTopStatusBarHeight(ivMyButton)
+        ivMyButton.addMargin(top = requireContext().statusBarHeight)
         rvThemes.adapter = adapter
         tvPurchaseTicketButton.setOnClickListener {
             goToPurchase()

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/hint/HintFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/hint/HintFragment.kt
@@ -1,5 +1,6 @@
 package com.nextroom.nextroom.presentation.ui.hint
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
@@ -8,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import com.nextroom.nextroom.presentation.R
 import com.nextroom.nextroom.presentation.base.BaseFragment
 import com.nextroom.nextroom.presentation.databinding.FragmentHintBinding
+import com.nextroom.nextroom.presentation.extension.enableFullScreen
 import com.nextroom.nextroom.presentation.extension.repeatOnStarted
 import com.nextroom.nextroom.presentation.extension.safeNavigate
 import com.nextroom.nextroom.presentation.extension.toTimerFormat
@@ -23,6 +25,11 @@ class HintFragment : BaseFragment<FragmentHintBinding>(FragmentHintBinding::infl
 
     private val gameViewModel: GameViewModel by activityViewModels()
     private var scrolled: Boolean = false
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        enableFullScreen()
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/presentation/src/main/res/layout/fragment_memo.xml
+++ b/presentation/src/main/res/layout/fragment_memo.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <include
         android:id="@+id/tb_memo"


### PR DESCRIPTION
## 작업 내용

- 메모화면 풀스크린 적용
- BaseFragment 에서 `setMarginTopStatusBarHeight` 제거

## 풀스크린 만드는 방법

1. onAttach() 에서 `enableFullScreen()` 호출
2. 레이아웃 xml 의 루트 레이아웃 속성으로 `android:fitsSystemWindows="true"` 설정

## AdminMainFragment 에서 `enableFullScreen()` 사용하지 않은 이유

AdminMainFragment 는 이미지가 StatusBar 영역까지 차지하고 있다. `enableFullScreen()` 을 사용할 경우 StatusBar 영역에 이미지가 넘어가지 못하기 때문에 다르게 처리된 것!

