### PR TITLE
결제 승인 처리 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.bundles.firebase)
     implementation(libs.timber)
+    implementation(libs.billing)
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)

--- a/app/src/main/java/com/nextroom/nextroom/di/BillingModule.kt
+++ b/app/src/main/java/com/nextroom/nextroom/di/BillingModule.kt
@@ -1,0 +1,23 @@
+package com.nextroom.nextroom.di
+
+import android.content.Context
+import com.nextroom.nextroom.NextRoomApplication
+import com.nextroom.nextroom.presentation.util.BillingClientLifecycle
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BillingModule {
+    @Singleton
+    @Provides
+    fun provideBillingClientLifecycle(
+        @ApplicationContext context: Context,
+    ): BillingClientLifecycle {
+        return BillingClientLifecycle.getInstance(context as NextRoomApplication)
+    }
+}

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/BillingViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/BillingViewModel.kt
@@ -19,26 +19,19 @@ import javax.inject.Inject
 @HiltViewModel
 class BillingViewModel @Inject constructor() : ViewModel() {
 
-    private lateinit var billingClientLifecycle: BillingClientLifecycle
-    private lateinit var purchases: StateFlow<List<Purchase>>
-    private lateinit var premiumSubProductWithProductDetails: MutableLiveData<ProductDetails?>
-    private lateinit var basicSubProductWithProductDetails: MutableLiveData<ProductDetails?>
-    private lateinit var oneTimeProductWithProductDetails: MutableLiveData<ProductDetails?>
+    // 사용자의 현재 구독 상품 구매 정보
+    private val purchases = billingClientLifecycle.subscriptionPurchases
 
-    fun setBillingClientLifecycle(billingClientLifecycle: BillingClientLifecycle) {
-        this.billingClientLifecycle = billingClientLifecycle
-        purchases = billingClientLifecycle.subscriptionPurchases
-        premiumSubProductWithProductDetails = billingClientLifecycle.premiumSubProductWithProductDetails
-        basicSubProductWithProductDetails = billingClientLifecycle.basicSubProductWithProductDetails
-        oneTimeProductWithProductDetails = billingClientLifecycle.oneTimeProductWithProductDetails
-    }
+    // 콘솔에 등록된 상품들 정보
+    private val premiumSubProductWithProductDetails = billingClientLifecycle.premiumSubProductWithProductDetails
+    private val basicSubProductWithProductDetails = billingClientLifecycle.basicSubProductWithProductDetails
+
+    val billingClientEvent = billingClientLifecycle.uiEvent
 
     private val _buyEvent = MutableSharedFlow<BillingFlowParams>()
     val buyEvent = _buyEvent.asSharedFlow()
 
     /**
-     * BillingFlowParams Builder for normal purchases.
-     *
      * @param productDetails ProductDetails object returned by the library.
      * @param offerToken the least priced offer's offer id token returned by
      * [leastPricedOfferToken].
@@ -46,14 +39,14 @@ class BillingViewModel @Inject constructor() : ViewModel() {
      * @return [BillingFlowParams] builder.
      */
     private fun billingFlowParamsBuilder(productDetails: ProductDetails, offerToken: String):
-            BillingFlowParams {
+        BillingFlowParams {
         return BillingFlowParams.newBuilder().setProductDetailsParamsList(
             listOf(
                 BillingFlowParams.ProductDetailsParams.newBuilder()
                     .setProductDetails(productDetails)
                     .setOfferToken(offerToken)
-                    .build()
-            )
+                    .build(),
+            ),
         ).build()
     }
 
@@ -68,24 +61,25 @@ class BillingViewModel @Inject constructor() : ViewModel() {
      * @return [BillingFlowParams] builder.
      */
     private fun upDowngradeBillingFlowParamsBuilder(
-        productDetails: ProductDetails, offerToken: String, oldToken: String
+        productDetails: ProductDetails,
+        offerToken: String,
+        oldToken: String,
     ): BillingFlowParams {
         return BillingFlowParams.newBuilder().setProductDetailsParamsList(
             listOf(
                 BillingFlowParams.ProductDetailsParams.newBuilder()
                     .setProductDetails(productDetails)
                     .setOfferToken(offerToken)
-                    .build()
-            )
+                    .build(),
+            ),
         ).setSubscriptionUpdateParams(
             BillingFlowParams.SubscriptionUpdateParams.newBuilder()
                 .setOldPurchaseToken(oldToken)
                 .setSubscriptionReplacementMode(
-                    BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_FULL_PRICE
-                ).build()
+                    BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_FULL_PRICE,
+                ).build(),
         ).build()
     }
-
 
     /**
      * Calculates the lowest priced offer amongst all eligible offers.
@@ -99,7 +93,7 @@ class BillingViewModel @Inject constructor() : ViewModel() {
      *
      */
     private fun leastPricedOfferToken(
-        offerDetails: List<ProductDetails.SubscriptionOfferDetails>
+        offerDetails: List<ProductDetails.SubscriptionOfferDetails>,
     ): String {
         var offerToken = String()
         var leastPricedOffer: ProductDetails.SubscriptionOfferDetails
@@ -131,9 +125,10 @@ class BillingViewModel @Inject constructor() : ViewModel() {
      *
      */
     private fun retrieveEligibleOffers(
-        offerDetails: MutableList<ProductDetails.SubscriptionOfferDetails>, tag: String
+        offerDetails: MutableList<ProductDetails.SubscriptionOfferDetails>,
+        tag: String,
     ):
-            List<ProductDetails.SubscriptionOfferDetails> {
+        List<ProductDetails.SubscriptionOfferDetails> {
         val eligibleOffers = emptyList<ProductDetails.SubscriptionOfferDetails>().toMutableList()
         offerDetails.forEach { offerDetail ->
             if (offerDetail.offerTags.contains(tag)) {
@@ -143,6 +138,7 @@ class BillingViewModel @Inject constructor() : ViewModel() {
         return eligibleOffers
     }
 
+    // 이미 구독 중인 상품이 있는지 체크
     private fun purchaseForProduct(purchases: List<Purchase>?, product: String): Purchase? {
         purchases?.let {
             for (purchase in it) {
@@ -154,22 +150,23 @@ class BillingViewModel @Inject constructor() : ViewModel() {
         return null
     }
 
+    // 이미 구독 중인 상품이 있는지 리턴 (로컬)
     fun deviceHasGooglePlaySubscription(purchases: List<Purchase>?, product: String) =
         purchaseForProduct(purchases, product) != null
 
     /**
-     * Use the Google Play Billing Library to make a purchase.
+     * 요금제 구매
      *
-     * @param tag String representing tags associated with offers and base plans.
-     * @param product Product being purchased.
-     * @param upDowngrade Boolean indicating if the purchase is an upgrade or downgrade and
-     * when converting from one base plan to another.
-     *
+     * @param tag: 요금제와 관련된 태그를 나타내는 문자열
+     * @param product: 구매 하려는 상품
+     * @param upDowngrade: 구매가 업그레이드 또는 다운그레이드인지, 요금제를 전환하려는 경우에 true
      */
     fun buyBasePlans(tag: String, product: String, upDowngrade: Boolean) {
-        // TODO JH: 내부 테스트 후 삭제 검토
-       // val isProductOnDevice = deviceHasGooglePlaySubscription(purchases.value, product)
-       // if (!isProductOnDevice) return
+        val isProductOnDevice = deviceHasGooglePlaySubscription(purchases.value, product)
+        if (isProductOnDevice) {
+            Timber.d("The user already owns this item: $product")
+            return
+        }
         val basicSubProductDetails = basicSubProductWithProductDetails.value ?: run {
             Timber.e("Could not find Basic product details.")
             return
@@ -179,7 +176,7 @@ class BillingViewModel @Inject constructor() : ViewModel() {
             basicSubProductDetails.subscriptionOfferDetails?.let { offerDetailsList ->
                 retrieveEligibleOffers(
                     offerDetails = offerDetailsList,
-                    tag = tag
+                    tag = tag,
                 )
             }
 
@@ -190,11 +187,11 @@ class BillingViewModel @Inject constructor() : ViewModel() {
     private fun launchFlow(
         upDowngrade: Boolean,
         offerToken: String,
-        productDetails: ProductDetails
+        productDetails: ProductDetails,
     ) {
         val currentSubscriptionPurchaseCount = purchases.value.count {
             it.products.contains(Constants.BASIC_PRODUCT) ||
-                    it.products.contains(Constants.PREMIUM_PRODUCT)
+                it.products.contains(Constants.PREMIUM_PRODUCT)
         }
         if (currentSubscriptionPurchaseCount > EXPECTED_SUBSCRIPTION_PURCHASE_LIST_SIZE) {
             Timber.e("There are more than one subscription purchases on the device.")
@@ -202,26 +199,25 @@ class BillingViewModel @Inject constructor() : ViewModel() {
 
             TODO(
                 "Handle this case better, such as by showing a dialog to the user or by " +
-                        "programmatically getting the correct purchase token."
+                    "programmatically getting the correct purchase token.",
             )
         }
 
         val oldToken = purchases.value.filter {
             it.products.contains(Constants.BASIC_PRODUCT) ||
-                    it.products.contains(Constants.PREMIUM_PRODUCT)
+                it.products.contains(Constants.PREMIUM_PRODUCT)
         }.firstOrNull { it.purchaseToken.isNotEmpty() }?.purchaseToken ?: ""
-
 
         val billingParams: BillingFlowParams = if (upDowngrade) {
             upDowngradeBillingFlowParamsBuilder(
                 productDetails = productDetails,
                 offerToken = offerToken,
-                oldToken = oldToken
+                oldToken = oldToken,
             )
         } else {
             billingFlowParamsBuilder(
                 productDetails = productDetails,
-                offerToken = offerToken
+                offerToken = offerToken,
             )
         }
 
@@ -232,6 +228,6 @@ class BillingViewModel @Inject constructor() : ViewModel() {
 
     companion object {
         const val TAG = "BillingViewModel"
-        const val EXPECTED_SUBSCRIPTION_PURCHASE_LIST_SIZE = 1
+        const val EXPECTED_SUBSCRIPTION_PURCHASE_LIST_SIZE = 1 // 가질 수 있는 최대 상품 개수
     }
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/BillingViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/BillingViewModel.kt
@@ -17,7 +17,10 @@ import javax.inject.Inject
 
 
 @HiltViewModel
-class BillingViewModel @Inject constructor() : ViewModel() {
+class BillingViewModel
+@Inject constructor(
+    billingClientLifecycle: BillingClientLifecycle,
+) : ViewModel() {
 
     // 사용자의 현재 구독 상품 구매 정보
     private val purchases = billingClientLifecycle.subscriptionPurchases

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/BillingViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/BillingViewModel.kt
@@ -161,16 +161,8 @@ class BillingViewModel
     }
 
     // 이미 구독 중인 상품이 있는지 체크
-    private fun purchaseForProduct(purchases: List<Purchase>?, product: String): Purchase? {
-        purchases?.let {
-            for (purchase in it) {
-                if (purchase.products[0] == product) {
-                    return purchase
-                }
-            }
-        }
-        return null
-    }
+    private fun purchaseForProduct(purchases: List<Purchase>?, product: String) =
+        purchases?.firstOrNull { it.products.first() == product }
 
     // 이미 구독 중인 상품이 있는지 리턴 (로컬)
     fun deviceHasGooglePlaySubscription(purchases: List<Purchase>?, product: String) =

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainActivity.kt
@@ -10,6 +10,7 @@ import com.nextroom.nextroom.presentation.R
 import com.nextroom.nextroom.presentation.databinding.ActivityMainBinding
 import com.nextroom.nextroom.presentation.extension.repeatOn
 import com.nextroom.nextroom.presentation.extension.repeatOnStarted
+import com.nextroom.nextroom.presentation.ui.billing.BillingViewModel
 import com.nextroom.nextroom.presentation.util.BillingClientLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainActivity.kt
@@ -12,6 +12,7 @@ import com.nextroom.nextroom.presentation.extension.repeatOn
 import com.nextroom.nextroom.presentation.extension.repeatOnStarted
 import com.nextroom.nextroom.presentation.util.BillingClientLifecycle
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -20,9 +21,8 @@ class MainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels()
     private val billingViewModel: BillingViewModel by viewModels()
 
-    private val billingClientLifecycle by lazy {
-        BillingClientLifecycle.getInstance(this)
-    }
+    @Inject
+    lateinit var billingClientLifecycle: BillingClientLifecycle
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,7 +30,6 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         lifecycle.addObserver(billingClientLifecycle)
-        billingViewModel.setBillingClientLifecycle(billingClientLifecycle)
 
         binding.fcvNavHost.apply {
             systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingEvent.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingEvent.kt
@@ -1,0 +1,6 @@
+package com.nextroom.nextroom.presentation.ui.billing
+
+sealed interface BillingEvent {
+    data object PurchaseAcknowledged : BillingEvent
+    data class PurchaseFailed(val purchaseState: Int) : BillingEvent
+}

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingViewModel.kt
@@ -1,10 +1,11 @@
-package com.nextroom.nextroom.presentation.ui
+package com.nextroom.nextroom.presentation.ui.billing
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
+import com.nextroom.nextroom.presentation.ui.Constants
 import com.nextroom.nextroom.presentation.util.BillingClientLifecycle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,14 +30,14 @@ class BillingViewModel
     private val _buyEvent = MutableSharedFlow<BillingFlowParams>()
     val buyEvent = _buyEvent.asSharedFlow()
 
-    private val _uiEvent = MutableSharedFlow<UIEvent>()
+    private val _uiEvent = MutableSharedFlow<BillingEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
     init {
         viewModelScope.launch {
             billingClientLifecycle.uiEvent.collect {
                 when (it) {
-                    BillingClientLifecycle.UIEvent.PurchaseAcknowledged -> _uiEvent.emit(UIEvent.PurchaseAcknowledged)
+                    BillingClientLifecycle.UIEvent.PurchaseAcknowledged -> _uiEvent.emit(BillingEvent.PurchaseAcknowledged)
                 }
             }
         }
@@ -46,7 +47,7 @@ class BillingViewModel
                     if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
                         billingClientLifecycle.acknowledgePurchase(purchase.purchaseToken)
                     } else {
-                        _uiEvent.emit(UIEvent.PurchaseFailed(purchaseState = purchase.purchaseState))
+                        _uiEvent.emit(BillingEvent.PurchaseFailed(purchaseState = purchase.purchaseState))
                     }
                 }
             }
@@ -238,11 +239,6 @@ class BillingViewModel
         viewModelScope.launch {
             _buyEvent.emit(billingParams)
         }
-    }
-
-    sealed interface UIEvent {
-        data object PurchaseAcknowledged : UIEvent
-        data class PurchaseFailed(val purchaseState: Int) : UIEvent
     }
 
     companion object {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseEvent.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseEvent.kt
@@ -1,7 +1,9 @@
 package com.nextroom.nextroom.presentation.ui.purchase
 
-import com.nextroom.nextroom.domain.model.Ticket
-
 sealed interface PurchaseEvent {
-    data class StartPurchase(val ticket: Ticket) : PurchaseEvent
+    data class StartPurchase(
+        val productId: String,
+        val tag: String,
+        val upDowngrade: Boolean,
+    ) : PurchaseEvent
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
@@ -13,9 +13,10 @@ import com.nextroom.nextroom.presentation.base.BaseFragment
 import com.nextroom.nextroom.presentation.common.LinearSpaceDecoration
 import com.nextroom.nextroom.presentation.databinding.FragmentPurchaseBinding
 import com.nextroom.nextroom.presentation.extension.dp
+import com.nextroom.nextroom.presentation.extension.repeatOnStarted
 import com.nextroom.nextroom.presentation.extension.safeNavigate
+import com.nextroom.nextroom.presentation.extension.toast
 import com.nextroom.nextroom.presentation.ui.BillingViewModel
-import com.nextroom.nextroom.presentation.util.BillingClientLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import org.orbitmvi.orbit.viewmodel.observe
 
@@ -32,6 +33,7 @@ class PurchaseFragment : BaseFragment<FragmentPurchaseBinding>(FragmentPurchaseB
 
         initViews()
         viewModel.observe(viewLifecycleOwner, state = ::render, sideEffect = ::handleEvent)
+        initObserve()
     }
 
     private fun initViews() = with(binding) {
@@ -71,8 +73,28 @@ class PurchaseFragment : BaseFragment<FragmentPurchaseBinding>(FragmentPurchaseB
     private fun handleEvent(event: PurchaseEvent) {
         when (event) {
             is PurchaseEvent.StartPurchase -> {
-                val action = PurchaseFragmentDirections.actionPurchaseFragmentToPurchaseSuccessFragment()
-                findNavController().safeNavigate(action)
+                billingViewModel.buyBasePlans(
+                    product = event.productId,
+                    tag = event.tag,
+                    upDowngrade = event.upDowngrade,
+                )
+            }
+        }
+    }
+
+    private fun initObserve() {
+        viewLifecycleOwner.repeatOnStarted {
+            billingViewModel.uiEvent.collect { event ->
+                when (event) {
+                    BillingViewModel.UIEvent.PurchaseAcknowledged -> {
+                        PurchaseFragmentDirections
+                            .actionPurchaseFragmentToPurchaseSuccessFragment()
+                            .also {
+                                findNavController().safeNavigate(it)
+                            }
+                    }
+                    is BillingViewModel.UIEvent.PurchaseFailed -> toast(getString(R.string.purchase_error_message, event.purchaseState))
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
@@ -16,7 +16,8 @@ import com.nextroom.nextroom.presentation.extension.dp
 import com.nextroom.nextroom.presentation.extension.repeatOnStarted
 import com.nextroom.nextroom.presentation.extension.safeNavigate
 import com.nextroom.nextroom.presentation.extension.toast
-import com.nextroom.nextroom.presentation.ui.BillingViewModel
+import com.nextroom.nextroom.presentation.ui.billing.BillingEvent
+import com.nextroom.nextroom.presentation.ui.billing.BillingViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import org.orbitmvi.orbit.viewmodel.observe
 
@@ -86,14 +87,14 @@ class PurchaseFragment : BaseFragment<FragmentPurchaseBinding>(FragmentPurchaseB
         viewLifecycleOwner.repeatOnStarted {
             billingViewModel.uiEvent.collect { event ->
                 when (event) {
-                    BillingViewModel.UIEvent.PurchaseAcknowledged -> {
+                    BillingEvent.PurchaseAcknowledged -> {
                         PurchaseFragmentDirections
                             .actionPurchaseFragmentToPurchaseSuccessFragment()
                             .also {
                                 findNavController().safeNavigate(it)
                             }
                     }
-                    is BillingViewModel.UIEvent.PurchaseFailed -> toast(getString(R.string.purchase_error_message, event.purchaseState))
+                    is BillingEvent.PurchaseFailed -> toast(getString(R.string.purchase_error_message, event.purchaseState))
                 }
             }
         }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.nextroom.nextroom.domain.model.SubscribeStatus
@@ -13,6 +14,8 @@ import com.nextroom.nextroom.presentation.common.LinearSpaceDecoration
 import com.nextroom.nextroom.presentation.databinding.FragmentPurchaseBinding
 import com.nextroom.nextroom.presentation.extension.dp
 import com.nextroom.nextroom.presentation.extension.safeNavigate
+import com.nextroom.nextroom.presentation.ui.BillingViewModel
+import com.nextroom.nextroom.presentation.util.BillingClientLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import org.orbitmvi.orbit.viewmodel.observe
 
@@ -20,6 +23,7 @@ import org.orbitmvi.orbit.viewmodel.observe
 class PurchaseFragment : BaseFragment<FragmentPurchaseBinding>(FragmentPurchaseBinding::inflate) {
 
     private val viewModel: PurchaseViewModel by viewModels()
+    private val billingViewModel: BillingViewModel by activityViewModels()
     private val adapter: TicketAdapter by lazy { TicketAdapter(viewModel::startPurchase) }
     private val spacer: LinearSpaceDecoration = LinearSpaceDecoration(spaceBetween = 12.dp)
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseViewModel.kt
@@ -30,7 +30,13 @@ class PurchaseViewModel @Inject constructor(
     }
 
     fun startPurchase(ticket: Ticket) = intent {
-        postSideEffect(PurchaseEvent.StartPurchase(ticket))
+        postSideEffect(
+            PurchaseEvent.StartPurchase(
+                productId = ticket.id.toString(),
+                tag = "",
+                upDowngrade = (ticket.id == container.stateFlow.value.userSubscribe?.type?.id),
+            ),
+        )
     }
 
     private fun fetchSubscribes() = intent {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/util/BillingClientLifecycle.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/util/BillingClientLifecycle.kt
@@ -31,31 +31,36 @@ import kotlin.math.pow
 class BillingClientLifecycle private constructor(
     private val applicationContext: Context,
     private val externalScope: CoroutineScope =
-        CoroutineScope(SupervisorJob() + Dispatchers.Default)
-) : DefaultLifecycleObserver, PurchasesUpdatedListener, BillingClientStateListener,
-    ProductDetailsResponseListener, PurchasesResponseListener {
+        CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : DefaultLifecycleObserver,
+    /*
+     * PurchasesUpdatedListener: 결제 상태가 업데이트될 때 감지
+     * BillingClientStateListener: Billing Client의 상태 변화 감지
+     * ProductDetailsResponseListener: 상품 정보를 검색하고 수신
+     * PurchasesResponseListener: 사용자의 인앱 구매 및 구독 상태 감지
+     */
+    PurchasesUpdatedListener,
+    BillingClientStateListener,
+    ProductDetailsResponseListener,
+    PurchasesResponseListener {
 
+    // 사용자의 현재 구독 상품 구매 정보
     private val _subscriptionPurchases = MutableStateFlow<List<Purchase>>(emptyList())
     val subscriptionPurchases = _subscriptionPurchases.asStateFlow()
 
-
-    /**
-     * Cached in-app product purchases details.
-     */
+    // 상품 정보 캐싱
     private var cachedPurchasesList: List<Purchase>? = null
 
-    /**
-     * ProductDetails for all known products.
-     */
+    // 콘솔에 등록된 상품들 정보
     val premiumSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
     val basicSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
-    val oneTimeProductWithProductDetails = MutableLiveData<ProductDetails?>()
 
     /**
      * Instantiate a new BillingClient instance.
      */
     private lateinit var billingClient: BillingClient
 
+    // onCreate때 billingClient를 생성하고 연결
     override fun onCreate(owner: LifecycleOwner) {
         billingClient = BillingClient.newBuilder(applicationContext)
             .setListener(this)
@@ -66,12 +71,18 @@ class BillingClientLifecycle private constructor(
         }
     }
 
+    // onDestroy때 billingClient 연결 해제
     override fun onDestroy(owner: LifecycleOwner) {
         if (billingClient.isReady) {
             billingClient.endConnection()
         }
     }
 
+    /*
+     * onBillingSetupFinished: billingClient 연결이 완료되면 호출됨
+     * querySubscriptionProductDetails: 구독 상품 정보 조회
+     * querySubscriptionPurchases: 사용자의 현재 구독 상품 구매 내역을 조회
+     */
     override fun onBillingSetupFinished(billingResult: BillingResult) {
         val responseCode = billingResult.responseCode
         val debugMessage = billingResult.debugMessage
@@ -84,17 +95,13 @@ class BillingClientLifecycle private constructor(
 
     override fun onBillingServiceDisconnected() {
         Timber.d("onBillingServiceDisconnected")
-        // TODO: Try connecting again with exponential backoff.
     }
 
     /**
-     * In order to make purchases, you need the [ProductDetails] for the item or subscription.
-     * This is an asynchronous call that will receive a result in [onProductDetailsResponse].
+     * 구매를 하려면 일회성 결제 또는 구독을 위한 [ProductDetails]가 필요
+     * 상품 정보 조회가 완료되면 [onProductDetailsResponse]가 호출됨
      *
-     * querySubscriptionProductDetails uses method calls from GPBL 5.0.0. PBL5, released in May 2022,
-     * is backwards compatible with previous versions.
-     * To learn more about this you can read:
-     * https://developer.android.com/google/play/billing/compatibility
+     * queryProductDetailsAsync: 상품 정보 조회
      */
     private fun querySubscriptionProductDetails() {
         val params = QueryProductDetailsParams.newBuilder()
@@ -105,7 +112,7 @@ class BillingClientLifecycle private constructor(
                 QueryProductDetailsParams.Product.newBuilder()
                     .setProductId(product)
                     .setProductType(BillingClient.ProductType.SUBS)
-                    .build()
+                    .build(),
             )
         }
 
@@ -114,12 +121,14 @@ class BillingClientLifecycle private constructor(
         }
     }
 
+    // 상품 정보 조회 완료시 호출됨
     override fun onProductDetailsResponse(
         billingResult: BillingResult,
-        productDetailsList: MutableList<ProductDetails>
+        productDetailsList: MutableList<ProductDetails>,
     ) {
         val response = BillingResponse(billingResult.responseCode)
         val debugMessage = billingResult.debugMessage
+
         when {
             response.isOk -> {
                 processProductDetails(productDetailsList)
@@ -133,29 +142,23 @@ class BillingClientLifecycle private constructor(
             else -> {
                 Timber.e("onProductDetailsResponse: " + response.code + " " + debugMessage)
             }
-
         }
     }
 
-    /**
-     * This method is used to process the product details list returned by the [BillingClient]and
-     * post the details to the [basicSubProductWithProductDetails] and
-     * [premiumSubProductWithProductDetails] live data.
-     *
-     * @param productDetailsList The list of product details.
-     *
-     */
     private fun processProductDetails(productDetailsList: MutableList<ProductDetails>) {
         val expectedProductDetailsCount = LIST_OF_SUBSCRIPTION_PRODUCTS.size
         if (productDetailsList.isEmpty()) {
-            Timber.e("processProductDetails: Expected $expectedProductDetailsCount, Found null ProductDetails. " +
-                    "Check to see if the products you requested are correctly published in the Google Play Console.")
+            Timber.e(
+                "processProductDetails: Expected $expectedProductDetailsCount, Found null ProductDetails. " +
+                    "Check to see if the products you requested are correctly published in the Google Play Console.",
+            )
             postProductDetails(emptyList())
         } else {
             postProductDetails(productDetailsList)
         }
     }
 
+    // 구글 콘솔에서 받아온 상품 정보를 저장
     private fun postProductDetails(productDetailsList: List<ProductDetails>) {
         productDetailsList.forEach { productDetails ->
             when (productDetails.productType) {
@@ -170,40 +173,33 @@ class BillingClientLifecycle private constructor(
         }
     }
 
-    /**
-     * Query Google Play Billing for existing subscription purchases.
-     *
-     * New purchases will be provided to the PurchasesUpdatedListener.
-     * You still need to check the Google Play Billing API to know when purchase tokens are removed.
-     */
+    // 사용자의 현재 구독 상품 구매 내역을 조회
     private fun querySubscriptionPurchases() {
         if (!billingClient.isReady) {
             Timber.e("querySubscriptionPurchases: BillingClient is not ready")
             billingClient.startConnection(this)
+        } else {
+            billingClient.queryPurchasesAsync(
+                QueryPurchasesParams.newBuilder()
+                    .setProductType(BillingClient.ProductType.SUBS)
+                    .build(),
+                this,
+            )
         }
-        billingClient.queryPurchasesAsync(
-            QueryPurchasesParams.newBuilder()
-                .setProductType(BillingClient.ProductType.SUBS)
-                .build(), this
-        )
     }
 
-    /**
-     * Callback from the billing library when queryPurchasesAsync is called.
-     */
+    // queryPurchasesAsync를 호출하여 사용자의 구독 상품 구매 내역을 조회가 끝나면 onQueryPurchasesResponse가 호출됨
     override fun onQueryPurchasesResponse(
         billingResult: BillingResult,
-        purchasesList: MutableList<Purchase>
+        purchasesList: MutableList<Purchase>,
     ) {
         processPurchases(purchasesList)
     }
 
-    /**
-     * Called by the Billing Library when new purchases are detected.
-     */
+    // 새로운 구매가 감지 되었을 때 콜백
     override fun onPurchasesUpdated(
         billingResult: BillingResult,
-        purchases: MutableList<Purchase>?
+        purchases: MutableList<Purchase>?,
     ) {
         val responseCode = billingResult.responseCode
         val debugMessage = billingResult.debugMessage
@@ -227,21 +223,22 @@ class BillingClientLifecycle private constructor(
             }
 
             BillingClient.BillingResponseCode.DEVELOPER_ERROR -> {
-                Timber.e("onPurchasesUpdated: Developer error means that Google Play does "
-                        + "not recognize the configuration. If you are just getting started, "
-                        + "make sure you have configured the application correctly in the "
-                        + "Google Play Console. The product ID must match and the APK you "
-                        + "are using must be signed with release keys.")
+                Timber.e(
+                    "onPurchasesUpdated: Developer error means that Google Play does " +
+                        "not recognize the configuration. If you are just getting started, " +
+                        "make sure you have configured the application correctly in the " +
+                        "Google Play Console. The product ID must match and the APK you " +
+                        "are using must be signed with release keys.",
+                )
             }
         }
     }
 
     /**
-     * Send purchase to StateFlow, which will trigger network call to verify the subscriptions
-     * on the sever.
+     * stateFlow로 사용자가 구매한 상품 목록을 방출
+     * observe 하는 곳에서 구독에 대한 자격 부여 처리(구글에 전송)
      */
     private fun processPurchases(purchasesList: List<Purchase>?) {
-        Timber.d("processPurchases: " + purchasesList?.size + " purchase(s)")
         purchasesList?.let { list ->
             if (isUnchangedPurchaseList(list)) {
                 Timber.d("processPurchases: Purchase list has not changed")
@@ -260,9 +257,7 @@ class BillingClientLifecycle private constructor(
         }
     }
 
-    /**
-     * Check whether the purchases have changed before posting changes.
-     */
+    // 상품 구매 내용이 이전과 다른지 체크
     private fun isUnchangedPurchaseList(purchasesList: List<Purchase>): Boolean {
         val isUnchanged = purchasesList == cachedPurchasesList
         if (!isUnchanged) {
@@ -272,14 +267,10 @@ class BillingClientLifecycle private constructor(
     }
 
     /**
-     * Log the number of purchases that are acknowledge and not acknowledged.
+     * 조회한 구매 목록 중에서 어떤 구매가 이미 확인(acknowledged)되었고
+     * 아직 확인되지 않은(unacknowledged) 구매가 있는지를 로그로 출력
      *
      * https://developer.android.com/google/play/billing/billing_library_releases_notes#2_0_acknowledge
-     *
-     * When the purchase is first received, it will not be acknowledge.
-     * This application sends the purchase token to the server for registration. After the
-     * purchase token is registered to an account, the Android app acknowledges the purchase token.
-     * The next time the purchase list is updated, it will contain acknowledged purchases.
      */
     private fun logAcknowledgementStatus(purchasesList: List<Purchase>) {
         var acknowledgedCounter = 0
@@ -294,11 +285,7 @@ class BillingClientLifecycle private constructor(
         Timber.d("logAcknowledgementStatus: acknowledged=$acknowledgedCounter unacknowledged=$unacknowledgedCounter")
     }
 
-    /**
-     * Launching the billing flow.
-     *
-     * Launching the UI to make a purchase requires a reference to the Activity.
-     */
+    // 결제 플로우 실행
     fun launchBillingFlow(activity: Activity, params: BillingFlowParams): Int {
         if (!billingClient.isReady) {
             Timber.e("launchBillingFlow: BillingClient is not ready")
@@ -310,80 +297,70 @@ class BillingClientLifecycle private constructor(
         return responseCode
     }
 
-    /**
-     * Acknowledge a purchase.
-     *
-     * https://developer.android.com/google/play/billing/billing_library_releases_notes#2_0_acknowledge
-     *
-     * Apps should acknowledge the purchase after confirming that the purchase token
-     * has been associated with a user. This app only acknowledges purchases after
-     * successfully receiving the subscription data back from the server.
-     *
-     * Developers can choose to acknowledge purchases from a server using the
-     * Google Play Developer API. The server has direct access to the user database,
-     * so using the Google Play Developer API for acknowledgement might be more reliable.
-     * TODO(134506821): Acknowledge purchases on the server.
-     * TODO: Remove client side purchase acknowledgement after removing the associated tests.
-     * If the purchase token is not acknowledged within 3 days,
-     * then Google Play will automatically refund and revoke the purchase.
-     * This behavior helps ensure that users are not charged for subscriptions unless the
-     * user has successfully received access to the content.
-     * This eliminates a category of issues where users complain to developers
-     * that they paid for something that the app is not giving to them.
-     */
-    suspend fun acknowledgePurchase(purchaseToken: String): Boolean {
+    // 구매 승인
+    suspend fun acknowledgePurchase(purchaseToken: String): Boolean = suspendCoroutine { continuation ->
         val params = AcknowledgePurchaseParams.newBuilder()
             .setPurchaseToken(purchaseToken)
             .build()
 
-        for (trial in 1..MAX_RETRY_ATTEMPT) {
-            var response = BillingResponse(500)
-            var bResult: BillingResult? = null
+        val maxRetryAttempt = MAX_RETRY_ATTEMPT
+        var currentTrial = 0
+
+        fun acknowledge() {
             billingClient.acknowledgePurchase(params) { billingResult ->
-                response = BillingResponse(billingResult.responseCode)
-                bResult = billingResult
-            }
+                val response = BillingResponse(billingResult.responseCode)
 
-            when {
-                response.isOk -> {
-                    Timber.i("Acknowledge success - token: $purchaseToken")
-                    return true
-                }
-
-                response.canFailGracefully -> {
-                    // Ignore the error
-                    Timber.i("Token $purchaseToken is already owned.")
-                    return true
-                }
-
-                response.isRecoverableError -> {
-                    // Retry to ack because these errors may be recoverable.
-                    val duration = 500L * 2.0.pow(trial).toLong()
-                    delay(duration)
-                    if (trial < MAX_RETRY_ATTEMPT) {
-                        Timber.w("Retrying(" + trial + ") to acknowledge for token "
-                                + purchaseToken
-                                + " - "
-                                + "code: "
-                                + bResult!!.responseCode
-                                + ", message: "
-                                + bResult!!.debugMessage)
+                when {
+                    response.isOk -> {
+                        Timber.i("Acknowledge success - token: $purchaseToken")
+                        externalScope.launch {
+                            _uiEvent.emit(UIEvent.PurchaseAcknowledged)
+                        }
+                        continuation.resume(true)
                     }
-                }
 
-                response.isNonrecoverableError || response.isTerribleFailure -> {
-                    Timber.e("Failed to acknowledge for token "
-                            + purchaseToken
-                            + " - "
-                            + "code: "
-                            + bResult!!.responseCode
-                            + ", message: "
-                            + bResult!!.debugMessage)
-                    break
+                    response.canFailGracefully -> {
+                        Timber.i("Token $purchaseToken is already owned.")
+                        continuation.resume(true)
+                    }
+
+                    response.isRecoverableError -> {
+                        if (currentTrial < maxRetryAttempt) {
+                            val duration = 500L * 2.0.pow(currentTrial).toLong()
+                            Timber.w(
+                                "Retrying($currentTrial) to acknowledge for token $purchaseToken - " +
+                                    "code: ${billingResult.responseCode}, message: ${billingResult.debugMessage}",
+                            )
+                            externalScope.launch {
+                                delay(duration)
+                                currentTrial++
+                                acknowledge()
+                            }
+                        } else {
+                            Timber.e(
+                                "Failed to acknowledge for token $purchaseToken - " +
+                                    "code: ${billingResult.responseCode}, message: ${billingResult.debugMessage}",
+                            )
+                            continuation.resume(false)
+                        }
+                    }
+
+                    response.isNonrecoverableError || response.isTerribleFailure -> {
+                        Timber.e(
+                            "Failed to acknowledge for token $purchaseToken - " +
+                                "code: ${billingResult.responseCode}, message: ${billingResult.debugMessage}",
+                        )
+                        continuation.resume(false)
+                    }
                 }
             }
         }
-        throw Exception("Failed to acknowledge the purchase!")
+
+        acknowledge()
+    }
+
+    sealed interface UIEvent {
+        data object PurchaseAcknowledged : UIEvent
     }
 
     companion object {
@@ -391,7 +368,8 @@ class BillingClientLifecycle private constructor(
         private const val MAX_RETRY_ATTEMPT = 3
 
         private val LIST_OF_SUBSCRIPTION_PRODUCTS = listOf(
-            Constants.BASIC_PRODUCT, Constants.PREMIUM_PRODUCT
+            Constants.BASIC_PRODUCT,
+            Constants.PREMIUM_PRODUCT,
         )
 
         @Volatile

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/util/BillingClientLifecycle.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/util/BillingClientLifecycle.kt
@@ -22,10 +22,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 import kotlin.math.pow
 
 class BillingClientLifecycle private constructor(
@@ -55,9 +59,9 @@ class BillingClientLifecycle private constructor(
     val premiumSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
     val basicSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
 
-    /**
-     * Instantiate a new BillingClient instance.
-     */
+    private val _uiEvent = MutableSharedFlow<UIEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
     private lateinit var billingClient: BillingClient
 
     // onCreate때 billingClient를 생성하고 연결

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="purchase_success_button">홈으로</string>
     <string name="purchase_success_title">결제가 완료되었어요</string>
     <string name="purchase_success_content">지금 바로 넥스트룸을 사용해보세요</string>
+    <string name="purchase_error_message">일시적인 오류이거나 서비스 장애입니다. 다시 시도하여도 해당 메시지가 계속 보일 경우 상태 코드와 함께 문의 바랍니다.\n상태 코드: %d</string>
     <string name="expire_period">구독 기간</string>
     <string name="mypage_button_description">마이페이지 이동</string>
     <string name="mypage_title">My</string>


### PR DESCRIPTION
## 작업 내용

- billing 뷰모델이랑 라이프사이클 쪽 주요 코드부분에 로직 설명을 주석(한글)으로 상세히 적어두었습니다.
- billingClientLifeCycle을 주입받는 방식으로 변경했습니다.
- 원래는 결제 신청 로직 밖에 없었는데, 결제 신청 후 승인 처리까지 하도록 구현하였습니다.
  - 승인 처리가 완료되면 결제 완료 페이지로 넘어갑니다.
  - 결제 신청 후 상태에 문제가 있으면 토스트를 띄우고 이용권 정보 페이지에 머무릅니다.