### PR TITLE
통계 기능 구현

### DIFF
--- a/app/src/main/java/com/nextroom/nextroom/di/RepositoryModule.kt
+++ b/app/src/main/java/com/nextroom/nextroom/di/RepositoryModule.kt
@@ -6,12 +6,14 @@ import com.nextroom.nextroom.data.datasource.BillingDataSource
 import com.nextroom.nextroom.data.datasource.HintLocalDataSource
 import com.nextroom.nextroom.data.datasource.HintRemoteDataSource
 import com.nextroom.nextroom.data.datasource.SettingDataSource
+import com.nextroom.nextroom.data.datasource.StatisticsDataSource
 import com.nextroom.nextroom.data.datasource.SubscriptionDataSource
 import com.nextroom.nextroom.data.datasource.ThemeLocalDataSource
 import com.nextroom.nextroom.data.datasource.ThemeRemoteDataSource
 import com.nextroom.nextroom.data.datasource.TokenDataSource
 import com.nextroom.nextroom.data.db.GameStateDao
 import com.nextroom.nextroom.data.db.HintDao
+import com.nextroom.nextroom.data.db.StatisticsDao
 import com.nextroom.nextroom.data.db.ThemeDao
 import com.nextroom.nextroom.data.db.ThemeTimeDao
 import com.nextroom.nextroom.data.network.ApiService
@@ -20,6 +22,7 @@ import com.nextroom.nextroom.data.repository.BillingRepositoryImpl
 import com.nextroom.nextroom.data.repository.DataStoreRepositoryImpl
 import com.nextroom.nextroom.data.repository.GameStateRepositoryImpl
 import com.nextroom.nextroom.data.repository.HintRepositoryImpl
+import com.nextroom.nextroom.data.repository.StatisticsRepositoryImpl
 import com.nextroom.nextroom.data.repository.ThemeRepositoryImpl
 import com.nextroom.nextroom.data.repository.TimerRepositoryImpl
 import com.nextroom.nextroom.domain.repository.AdminRepository
@@ -27,6 +30,7 @@ import com.nextroom.nextroom.domain.repository.BillingRepository
 import com.nextroom.nextroom.domain.repository.DataStoreRepository
 import com.nextroom.nextroom.domain.repository.GameStateRepository
 import com.nextroom.nextroom.domain.repository.HintRepository
+import com.nextroom.nextroom.domain.repository.StatisticsRepository
 import com.nextroom.nextroom.domain.repository.ThemeRepository
 import com.nextroom.nextroom.domain.repository.TimerRepository
 import dagger.Module
@@ -168,5 +172,12 @@ object RepositoryModule {
         return DataStoreRepositoryImpl(
             settingDataSource,
         )
+    }
+
+    @Provides
+    fun provideStatisticsRepository(
+        dataSource: StatisticsDataSource,
+    ): StatisticsRepository {
+        return StatisticsRepositoryImpl(dataSource)
     }
 }

--- a/commonutil/src/main/java/com/mangbaam/commonutil/DateTimeUtil.kt
+++ b/commonutil/src/main/java/com/mangbaam/commonutil/DateTimeUtil.kt
@@ -48,6 +48,10 @@ class DateTimeUtil(private val locale: Locale = Locale.getDefault()) {
         return (timeDiff / (1000 * 60 * 60 * 24)).toInt()
     }
 
+    fun currentTime(
+        pattern: String = dateFormatString,
+    ) = longToDateString(System.currentTimeMillis(), pattern)
+
     private fun SimpleDateFormat.safeParse(pattern: String): Date? {
         return try {
             parse(pattern)

--- a/data/src/main/java/com/nextroom/nextroom/data/datasource/StatisticsDataSource.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/datasource/StatisticsDataSource.kt
@@ -1,0 +1,29 @@
+package com.nextroom.nextroom.data.datasource
+
+import com.nextroom.nextroom.data.db.StatisticsDao
+import com.nextroom.nextroom.data.model.toEntity
+import com.nextroom.nextroom.data.network.ApiService
+import com.nextroom.nextroom.domain.model.statistics.GameStats
+import com.nextroom.nextroom.domain.model.statistics.HintStats
+import javax.inject.Inject
+
+class StatisticsDataSource @Inject constructor(
+    private val statsDao: StatisticsDao,
+    private val apiService: ApiService,
+) {
+    suspend fun recordGameStartStats(gameStats: GameStats) {
+        statsDao.insertGameStats(gameStats.toEntity())
+    }
+
+    suspend fun recordHintStats(hintStats: HintStats) {
+        statsDao.insertHintStatsForLastGame(hintStats.toEntity())
+    }
+
+    suspend fun postGameStats() {
+        /*apiService.postGameStats().onSuspendSuccess {
+            statsDao.deleteAllGameStats()
+        }.onFailure {
+            TODO API 나온 후 구현 필요
+        }*/
+    }
+}

--- a/data/src/main/java/com/nextroom/nextroom/data/datasource/StatisticsDataSource.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/datasource/StatisticsDataSource.kt
@@ -3,9 +3,16 @@ package com.nextroom.nextroom.data.datasource
 import androidx.room.Transaction
 import com.nextroom.nextroom.data.db.StatisticsDao
 import com.nextroom.nextroom.data.model.toEntity
+import com.nextroom.nextroom.data.model.toRequest
 import com.nextroom.nextroom.data.network.ApiService
+import com.nextroom.nextroom.data.network.request.StatisticsRequest
+import com.nextroom.nextroom.domain.model.onFailure
 import com.nextroom.nextroom.domain.model.statistics.GameStats
 import com.nextroom.nextroom.domain.model.statistics.HintStats
+import com.nextroom.nextroom.domain.model.suspendOnSuccess
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 import javax.inject.Inject
 
 class StatisticsDataSource @Inject constructor(
@@ -32,14 +39,27 @@ class StatisticsDataSource @Inject constructor(
         val lastGameStats = statsDao.getLastGameStats() ?: return
         val lastHintStats = statsDao.getLastHintStats(lastGameStats.id, hintId) ?: return
 
-        statsDao.updateHintStats(lastHintStats.copy(answerOpenTime = answerOpenTime).apply { statsId = lastGameStats.id })
+        statsDao.updateHintStats(
+            lastHintStats.copy(answerOpenTime = answerOpenTime).apply { statsId = lastGameStats.id },
+        )
     }
 
     suspend fun postGameStats() {
-        /*apiService.postGameStats().onSuspendSuccess {
-            statsDao.deleteAllGameStats()
-        }.onFailure {
-            TODO API 나온 후 구현 필요
-        }*/
+        statsDao.getAllGameStats().forEach { gameStats ->
+            withContext(Dispatchers.IO) {
+                val hints = statsDao.getHintStatsForGame(gameStats.id)
+                val request = StatisticsRequest(
+                    themeId = gameStats.themeId,
+                    gameStartTime = gameStats.startTime,
+                    hint = hints.map { it.toRequest() },
+                )
+                apiService.postGameStats(request).suspendOnSuccess {
+                    Timber.tag("MANGBAAM-StatisticsDataSource(postGameStats)").d("통계 전송 성공")
+                    statsDao.deleteGameStats(gameStats)
+                }.onFailure {
+                    Timber.tag("MANGBAAM-StatisticsDataSource(postGameStats)").d("통계 전송 실패: $it")
+                }
+            }
+        }
     }
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/db/NextRoomDatabase.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/NextRoomDatabase.kt
@@ -4,13 +4,15 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.nextroom.nextroom.data.model.GameStateEntity
+import com.nextroom.nextroom.data.model.GameStatsEntity
 import com.nextroom.nextroom.data.model.HintEntity
+import com.nextroom.nextroom.data.model.HintStatsEntity
 import com.nextroom.nextroom.data.model.ThemeEntity
 import com.nextroom.nextroom.data.model.ThemeTimeEntity
 
 @Database(
-    entities = [ThemeEntity::class, ThemeTimeEntity::class, HintEntity::class, GameStateEntity::class],
-    version = 1,
+    entities = [ThemeEntity::class, ThemeTimeEntity::class, HintEntity::class, GameStateEntity::class, GameStatsEntity::class, HintStatsEntity::class],
+    version = 2,
 )
 @TypeConverters(TypeConverter::class)
 abstract class NextRoomDatabase : RoomDatabase() {
@@ -18,6 +20,7 @@ abstract class NextRoomDatabase : RoomDatabase() {
     abstract fun themeTimeDao(): ThemeTimeDao
     abstract fun hintDao(): HintDao
     abstract fun gameStateDao(): GameStateDao
+    abstract fun statisticsDao(): StatisticsDao
 
     companion object {
         const val DB_NAME = "NEXT_ROOM_DB"

--- a/data/src/main/java/com/nextroom/nextroom/data/db/NextRoomDatabase.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/NextRoomDatabase.kt
@@ -12,7 +12,7 @@ import com.nextroom.nextroom.data.model.ThemeTimeEntity
 
 @Database(
     entities = [ThemeEntity::class, ThemeTimeEntity::class, HintEntity::class, GameStateEntity::class, GameStatsEntity::class, HintStatsEntity::class],
-    version = 2,
+    version = 1,
 )
 @TypeConverters(TypeConverter::class)
 abstract class NextRoomDatabase : RoomDatabase() {

--- a/data/src/main/java/com/nextroom/nextroom/data/db/StatisticsDao.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/StatisticsDao.kt
@@ -3,33 +3,30 @@ package com.nextroom.nextroom.data.db
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Transaction
+import androidx.room.Update
 import com.nextroom.nextroom.data.model.GameStatsEntity
 import com.nextroom.nextroom.data.model.GameStatsEntity.Companion.GAME_STATS_TABLE
 import com.nextroom.nextroom.data.model.HintStatsEntity
+import com.nextroom.nextroom.data.model.HintStatsEntity.Companion.HINT_STATS_TABLE
 
 @Dao
 interface StatisticsDao {
     @Insert
     suspend fun insertGameStats(gameState: GameStatsEntity)
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertHintStats(hintStats: HintStatsEntity)
 
     @Query("SELECT * FROM $GAME_STATS_TABLE ORDER BY id DESC LIMIT 1")
     suspend fun getLastGameStats(): GameStatsEntity?
 
-    @Transaction
-    suspend fun insertHintStatsForLastGame(hintStats: HintStatsEntity) {
-        getLastGameStats()?.let { lastGameStats ->
-            insertHintStats(
-                hintStats.apply {
-                    statsId = lastGameStats.id
-                },
-            )
-        }
-    }
+    @Query("SELECT * FROM $HINT_STATS_TABLE WHERE statsId = :statsId AND hintId = :hintId ORDER BY id DESC LIMIT 1")
+    suspend fun getLastHintStats(statsId: Long, hintId: Int): HintStatsEntity?
+
+    @Update
+    suspend fun updateHintStats(hintStats: HintStatsEntity)
 
     @Query("SELECT * FROM $GAME_STATS_TABLE ORDER BY id")
     suspend fun getAllGameStats(): List<GameStatsEntity>

--- a/data/src/main/java/com/nextroom/nextroom/data/db/StatisticsDao.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/StatisticsDao.kt
@@ -31,6 +31,9 @@ interface StatisticsDao {
     @Query("SELECT * FROM $GAME_STATS_TABLE ORDER BY id")
     suspend fun getAllGameStats(): List<GameStatsEntity>
 
+    @Query("SELECT * FROM $HINT_STATS_TABLE WHERE statsId = :statsId ORDER BY id")
+    suspend fun getHintStatsForGame(statsId: Long): List<HintStatsEntity>
+
     @Query("DELETE FROM $GAME_STATS_TABLE")
     suspend fun deleteAllGameStats()
 

--- a/data/src/main/java/com/nextroom/nextroom/data/db/StatisticsDao.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/StatisticsDao.kt
@@ -1,0 +1,42 @@
+package com.nextroom.nextroom.data.db
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import com.nextroom.nextroom.data.model.GameStatsEntity
+import com.nextroom.nextroom.data.model.GameStatsEntity.Companion.GAME_STATS_TABLE
+import com.nextroom.nextroom.data.model.HintStatsEntity
+
+@Dao
+interface StatisticsDao {
+    @Insert
+    suspend fun insertGameStats(gameState: GameStatsEntity)
+
+    @Insert
+    suspend fun insertHintStats(hintStats: HintStatsEntity)
+
+    @Query("SELECT * FROM $GAME_STATS_TABLE ORDER BY id DESC LIMIT 1")
+    suspend fun getLastGameStats(): GameStatsEntity?
+
+    @Transaction
+    suspend fun insertHintStatsForLastGame(hintStats: HintStatsEntity) {
+        getLastGameStats()?.let { lastGameStats ->
+            insertHintStats(
+                hintStats.apply {
+                    statsId = lastGameStats.id
+                },
+            )
+        }
+    }
+
+    @Query("SELECT * FROM $GAME_STATS_TABLE ORDER BY id")
+    suspend fun getAllGameStats(): List<GameStatsEntity>
+
+    @Query("DELETE FROM $GAME_STATS_TABLE")
+    suspend fun deleteAllGameStats()
+
+    @Delete
+    suspend fun deleteGameStats(gameStats: GameStatsEntity)
+}

--- a/data/src/main/java/com/nextroom/nextroom/data/di/LocalDataModule.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/di/LocalDataModule.kt
@@ -3,12 +3,15 @@ package com.nextroom.nextroom.data.di
 import android.content.Context
 import androidx.room.Room
 import com.nextroom.nextroom.data.datasource.HintLocalDataSource
+import com.nextroom.nextroom.data.datasource.StatisticsDataSource
 import com.nextroom.nextroom.data.db.GameStateDao
 import com.nextroom.nextroom.data.db.HintDao
 import com.nextroom.nextroom.data.db.NextRoomDatabase
 import com.nextroom.nextroom.data.db.NextRoomDatabase.Companion.DB_NAME
+import com.nextroom.nextroom.data.db.StatisticsDao
 import com.nextroom.nextroom.data.db.ThemeDao
 import com.nextroom.nextroom.data.db.ThemeTimeDao
+import com.nextroom.nextroom.data.network.ApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -58,4 +61,16 @@ object LocalDataModule {
     fun provideHintLocalDataSource(hintDao: HintDao): HintLocalDataSource {
         return HintLocalDataSource(hintDao)
     }
+
+    @Singleton
+    @Provides
+    fun provideStatisticsDao(nextRoomDatabase: NextRoomDatabase): StatisticsDao {
+        return nextRoomDatabase.statisticsDao()
+    }
+
+    @Provides
+    fun provideStatisticsDataSource(
+        statsDao: StatisticsDao,
+        apiService: ApiService,
+    ): StatisticsDataSource = StatisticsDataSource(statsDao, apiService)
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/model/StatisticsEntity.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/model/StatisticsEntity.kt
@@ -1,0 +1,61 @@
+package com.nextroom.nextroom.data.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+import com.nextroom.nextroom.data.model.GameStatsEntity.Companion.GAME_STATS_TABLE
+import com.nextroom.nextroom.data.model.HintStatsEntity.Companion.HINT_STATS_TABLE
+import com.nextroom.nextroom.domain.model.statistics.GameStats
+import com.nextroom.nextroom.domain.model.statistics.HintStats
+
+@Entity(tableName = GAME_STATS_TABLE)
+data class GameStatsEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val themeId: Int,
+    val startTime: String,
+) {
+    companion object {
+        const val GAME_STATS_TABLE = "GameStatisticsTable"
+    }
+}
+
+fun GameStats.toEntity(): GameStatsEntity {
+    return GameStatsEntity(
+        themeId = themeId,
+        startTime = startTime,
+    )
+}
+
+@Entity(
+    tableName = HINT_STATS_TABLE,
+    foreignKeys = [
+        ForeignKey(
+            entity = GameStatsEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["statsId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+)
+data class HintStatsEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val hintId: Int,
+    val hintOpenTime: String,
+    val answerOpenTime: String?,
+) {
+    var statsId: Long = 0
+
+    companion object {
+        const val HINT_STATS_TABLE = "HintStatisticsTable"
+    }
+}
+
+fun HintStats.toEntity(): HintStatsEntity {
+    return HintStatsEntity(
+        hintId = hintId,
+        hintOpenTime = hintOpenTime,
+        answerOpenTime = answerOpenTime,
+    )
+}

--- a/data/src/main/java/com/nextroom/nextroom/data/model/StatisticsEntity.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/model/StatisticsEntity.kt
@@ -2,6 +2,7 @@ package com.nextroom.nextroom.data.model
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.nextroom.nextroom.data.model.GameStatsEntity.Companion.GAME_STATS_TABLE
 import com.nextroom.nextroom.data.model.HintStatsEntity.Companion.HINT_STATS_TABLE
@@ -37,6 +38,7 @@ fun GameStats.toEntity(): GameStatsEntity {
             onDelete = ForeignKey.CASCADE,
         ),
     ],
+    indices = [Index(value = ["statsId", "hintId"], unique = true)],
 )
 data class HintStatsEntity(
     @PrimaryKey(autoGenerate = true)

--- a/data/src/main/java/com/nextroom/nextroom/data/model/StatisticsEntity.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/model/StatisticsEntity.kt
@@ -6,6 +6,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.nextroom.nextroom.data.model.GameStatsEntity.Companion.GAME_STATS_TABLE
 import com.nextroom.nextroom.data.model.HintStatsEntity.Companion.HINT_STATS_TABLE
+import com.nextroom.nextroom.data.network.request.StatisticsRequest
 import com.nextroom.nextroom.domain.model.statistics.GameStats
 import com.nextroom.nextroom.domain.model.statistics.HintStats
 
@@ -60,4 +61,8 @@ fun HintStats.toEntity(): HintStatsEntity {
         hintOpenTime = hintOpenTime,
         answerOpenTime = answerOpenTime,
     )
+}
+
+fun HintStatsEntity.toRequest(): StatisticsRequest.HintRequest {
+    return StatisticsRequest.HintRequest(id = hintId, entryTime = hintOpenTime, answerOpenTime = answerOpenTime)
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/network/ApiService.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/network/ApiService.kt
@@ -2,6 +2,7 @@ package com.nextroom.nextroom.data.network
 
 import com.nextroom.nextroom.data.model.TokenDto
 import com.nextroom.nextroom.data.network.request.LoginRequest
+import com.nextroom.nextroom.data.network.request.StatisticsRequest
 import com.nextroom.nextroom.data.network.response.BaseListResponse
 import com.nextroom.nextroom.data.network.response.BaseResponse
 import com.nextroom.nextroom.data.network.response.HintDto
@@ -39,4 +40,7 @@ interface ApiService {
 
     @GET("api/v1/subscription/plan")
     suspend fun getSubscriptionPlans(): Result<BaseListResponse<TicketDto>>
+
+    @POST("api/v1/history")
+    suspend fun postGameStats(@Body statsRequest: StatisticsRequest): Result<Unit>
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/network/request/StatisticsRequest.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/network/request/StatisticsRequest.kt
@@ -1,0 +1,13 @@
+package com.nextroom.nextroom.data.network.request
+
+data class StatisticsRequest(
+    val themeId: Int,
+    val gameStartTime: String,
+    val hint: List<HintRequest>,
+) {
+    data class HintRequest(
+        val id: Int,
+        val entryTime: String,
+        val answerOpenTime: String?,
+    )
+}

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/StatisticsRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.nextroom.nextroom.data.datasource.StatisticsDataSource
 import com.nextroom.nextroom.domain.model.statistics.GameStats
 import com.nextroom.nextroom.domain.model.statistics.HintStats
 import com.nextroom.nextroom.domain.repository.StatisticsRepository
+import timber.log.Timber
 import javax.inject.Inject
 
 class StatisticsRepositoryImpl @Inject constructor(
@@ -23,6 +24,7 @@ class StatisticsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun postGameStats() {
+        Timber.tag("MANGBAAM-StatisticsRepositoryImpl(postGameStats)").d("게임 통계 전송 시도")
         dataSource.postGameStats()
     }
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/StatisticsRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.nextroom.nextroom.data.repository
+
+import com.nextroom.nextroom.data.datasource.StatisticsDataSource
+import com.nextroom.nextroom.domain.model.statistics.GameStats
+import com.nextroom.nextroom.domain.model.statistics.HintStats
+import com.nextroom.nextroom.domain.repository.StatisticsRepository
+import javax.inject.Inject
+
+class StatisticsRepositoryImpl @Inject constructor(
+    private val dataSource: StatisticsDataSource,
+) : StatisticsRepository {
+
+    override suspend fun recordGameStartStats(gameStats: GameStats) {
+        dataSource.recordGameStartStats(gameStats)
+    }
+
+    override suspend fun recordHintStats(hintStats: HintStats) {
+        dataSource.recordHintStats(hintStats)
+    }
+
+    override suspend fun postGameStats() {
+        dataSource.postGameStats()
+    }
+}

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/StatisticsRepositoryImpl.kt
@@ -18,6 +18,10 @@ class StatisticsRepositoryImpl @Inject constructor(
         dataSource.recordHintStats(hintStats)
     }
 
+    override suspend fun recordAnswerOpenTime(hintId: Int, answerOpenTime: String) {
+        dataSource.updateAnswerOpenTime(hintId, answerOpenTime)
+    }
+
     override suspend fun postGameStats() {
         dataSource.postGameStats()
     }

--- a/domain/src/main/java/com/nextroom/nextroom/domain/model/statistics/GameStats.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/model/statistics/GameStats.kt
@@ -1,0 +1,6 @@
+package com.nextroom.nextroom.domain.model.statistics
+
+data class GameStats(
+    val themeId: Int,
+    val startTime: String,
+)

--- a/domain/src/main/java/com/nextroom/nextroom/domain/model/statistics/HintStats.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/model/statistics/HintStats.kt
@@ -1,0 +1,7 @@
+package com.nextroom.nextroom.domain.model.statistics
+
+data class HintStats(
+    val hintId: Int,
+    val hintOpenTime: String,
+    val answerOpenTime: String,
+)

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/StatisticsRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/StatisticsRepository.kt
@@ -5,8 +5,7 @@ import com.nextroom.nextroom.domain.model.statistics.HintStats
 
 interface StatisticsRepository {
     suspend fun recordGameStartStats(gameStats: GameStats)
-
     suspend fun recordHintStats(hintStats: HintStats)
-
+    suspend fun recordAnswerOpenTime(hintId: Int, answerOpenTime: String)
     suspend fun postGameStats()
 }

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/StatisticsRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/StatisticsRepository.kt
@@ -1,0 +1,12 @@
+package com.nextroom.nextroom.domain.repository
+
+import com.nextroom.nextroom.domain.model.statistics.GameStats
+import com.nextroom.nextroom.domain.model.statistics.HintStats
+
+interface StatisticsRepository {
+    suspend fun recordGameStartStats(gameStats: GameStats)
+
+    suspend fun recordHintStats(hintStats: HintStats)
+
+    suspend fun postGameStats()
+}

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
@@ -6,8 +6,10 @@ import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.nextroom.nextroom.domain.model.SubscribeStatus
+import com.nextroom.nextroom.domain.repository.StatisticsRepository
 import com.nextroom.nextroom.presentation.R
 import com.nextroom.nextroom.presentation.base.BaseFragment
 import com.nextroom.nextroom.presentation.common.NRImageDialog
@@ -16,12 +18,17 @@ import com.nextroom.nextroom.presentation.extension.addMargin
 import com.nextroom.nextroom.presentation.extension.safeNavigate
 import com.nextroom.nextroom.presentation.extension.statusBarHeight
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.viewmodel.observe
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMainBinding::inflate) {
 
     private lateinit var backCallback: OnBackPressedCallback
+
+    @Inject
+    lateinit var statisticsRepository: StatisticsRepository
 
     private val viewModel: AdminMainViewModel by viewModels()
     private val adapter: ThemesAdapter by lazy {
@@ -49,6 +56,15 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
 
         initViews()
         viewModel.observe(viewLifecycleOwner, state = ::render)
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        lifecycleScope.launch {
+            // 통계 정보 서버에 전송
+            statisticsRepository.postGameStats()
+        }
     }
 
     private fun startGame(code: Int) {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/hint/HintViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/hint/HintViewModel.kt
@@ -2,6 +2,9 @@ package com.nextroom.nextroom.presentation.ui.hint
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.mangbaam.commonutil.DateTimeUtil
+import com.nextroom.nextroom.domain.model.statistics.HintStats
+import com.nextroom.nextroom.domain.repository.StatisticsRepository
 import com.nextroom.nextroom.domain.repository.TimerRepository
 import com.nextroom.nextroom.presentation.base.BaseViewModel
 import com.nextroom.nextroom.presentation.model.Hint
@@ -17,21 +20,31 @@ import javax.inject.Inject
 class HintViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val timerRepository: TimerRepository,
+    private val statsRepository: StatisticsRepository,
 ) : BaseViewModel<HintState, HintEvent>() {
-    override val container: Container<HintState, HintEvent> = container(
-        HintState(
-            hint = savedStateHandle.get<Hint>("hint") ?: Hint(),
-        ),
-    )
+
+    override val container: Container<HintState, HintEvent> =
+        container(HintState(hint = savedStateHandle.get<Hint>("hint") ?: Hint()))
+
+    private val state: HintState
+        get() = container.stateFlow.value
+
+    private val dateTimeUtil: DateTimeUtil by lazy { DateTimeUtil() }
 
     init {
         viewModelScope.launch {
             timerRepository.lastSeconds.collect(::tick)
         }
+        viewModelScope.launch {
+            // 힌트 오픈 시간 통계 집계
+            statsRepository.recordHintStats(HintStats(state.hint.id, DateTimeUtil().currentTime() ?: "", ""))
+        }
     }
 
     fun openAnswer() = intent {
         reduce { state.copy(hint = state.hint.copy(answerOpened = true)) }
+        // 정답 오픈 시간 통계 집계
+        statsRepository.recordAnswerOpenTime(state.hint.id, dateTimeUtil.currentTime() ?: "")
     }
 
     private fun tick(lastSeconds: Int) = intent {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameViewModel.kt
@@ -2,9 +2,12 @@ package com.nextroom.nextroom.presentation.ui.main
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.mangbaam.commonutil.DateTimeUtil
 import com.nextroom.nextroom.domain.model.TimerState
+import com.nextroom.nextroom.domain.model.statistics.GameStats
 import com.nextroom.nextroom.domain.repository.GameStateRepository
 import com.nextroom.nextroom.domain.repository.HintRepository
+import com.nextroom.nextroom.domain.repository.StatisticsRepository
 import com.nextroom.nextroom.domain.repository.ThemeRepository
 import com.nextroom.nextroom.domain.repository.TimerRepository
 import com.nextroom.nextroom.presentation.R
@@ -30,6 +33,7 @@ class GameViewModel @Inject constructor(
     private val timerRepository: TimerRepository,
     private val gameStateRepository: GameStateRepository,
     private val hintRepository: HintRepository,
+    private val statsRepository: StatisticsRepository,
 ) : BaseViewModel<GameScreenState, GameEvent>() {
 
     override val container: Container<GameScreenState, GameEvent> = container(GameScreenState())
@@ -67,6 +71,9 @@ class GameViewModel @Inject constructor(
                     Timber.tag("MANGBAAM-GameViewModel(startGame)").d("overflow: $it")
                 }
                 startGame(it.timeLimit - overflowTime)
+
+                // 게임 시작 통계 집계 시작
+                statsRepository.recordGameStartStats(GameStats(it.id, DateTimeUtil().currentTime() ?: ""))
             }
         }
     }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseViewModel.kt
@@ -35,9 +35,9 @@ class PurchaseViewModel @Inject constructor(
     fun startPurchase(ticket: Ticket) = intent {
         postSideEffect(
             PurchaseEvent.StartPurchase(
-                productId = ticket.id.toString(),
+                productId = ticket.id,
                 tag = "",
-                upDowngrade = (ticket.id == container.stateFlow.value.userSubscribe?.type?.id),
+                upDowngrade = (ticket.id == container.stateFlow.value.userSubscription?.type?.id),
             ),
         )
     }


### PR DESCRIPTION
## 수집 데이터

- 게임 시작 정보
- 힌트 데이터 (리스트)
  - 힌트 최초 오픈 시간
  - 정답 오픈 시간 (nullable)

## 작업 내용

위에 언급한 데이터를 수집하여 서버로 전송하는 로직 구현. 앱이 종료되거나 네트워크 문제로 서버에 전송을 실패하는 케이스를 고려하여 데이터를 수집한 즉시 내부 DB 에 저장하고, 서버에 전송 성공 시 로컬 데이터를 지우며, 실패한 경우 다음 기회에 다시 전송 시도. (서버 수신 확인 완료)

통계 데이터 전송 시점은 **테마 선택 화면**

## 전달 사항

DB 버전을 1로 초기화했기 때문에 앱 내부데이터 초기화 필요!
