### PR TITLE
purchaseToken 전송 API 연동, 새로 설정한 구독 상품에 맞게 대응

### DIFF
--- a/data/src/main/java/com/nextroom/nextroom/data/datasource/BillingDataSource.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/datasource/BillingDataSource.kt
@@ -1,9 +1,14 @@
 package com.nextroom.nextroom.data.datasource
 
+import com.nextroom.nextroom.data.network.ApiService
+import com.nextroom.nextroom.data.network.request.PurchaseToken
+import com.nextroom.nextroom.domain.model.Result
 import javax.inject.Inject
 
 class BillingDataSource @Inject constructor(
-
+    private val apiService: ApiService,
 ) {
-
+    suspend fun postPurchaseToken(purchaseToken: PurchaseToken): Result<Unit> {
+        return apiService.postPurchaseToken(purchaseToken)
+    }
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/network/ApiService.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/network/ApiService.kt
@@ -2,6 +2,7 @@ package com.nextroom.nextroom.data.network
 
 import com.nextroom.nextroom.data.model.TokenDto
 import com.nextroom.nextroom.data.network.request.LoginRequest
+import com.nextroom.nextroom.data.network.request.PurchaseToken
 import com.nextroom.nextroom.data.network.request.StatisticsRequest
 import com.nextroom.nextroom.data.network.response.BaseListResponse
 import com.nextroom.nextroom.data.network.response.BaseResponse
@@ -43,4 +44,7 @@ interface ApiService {
 
     @POST("api/v1/history")
     suspend fun postGameStats(@Body statsRequest: StatisticsRequest): Result<Unit>
+
+    @POST("api/v1/payment/purchase")
+    suspend fun postPurchaseToken(@Body purchaseToken: PurchaseToken): Result<Unit>
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/network/request/PurchaseToken.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/network/request/PurchaseToken.kt
@@ -1,0 +1,7 @@
+package com.nextroom.nextroom.data.network.request
+
+import com.google.gson.annotations.SerializedName
+
+data class PurchaseToken(
+    @SerializedName("purchaseToken") val purchaseToken: String,
+)

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/BillingRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/BillingRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.nextroom.nextroom.data.repository
 
 import com.nextroom.nextroom.data.datasource.BillingDataSource
 import com.nextroom.nextroom.data.datasource.SubscriptionDataSource
+import com.nextroom.nextroom.data.network.request.PurchaseToken
 import com.nextroom.nextroom.domain.model.Result
 import com.nextroom.nextroom.domain.model.Ticket
 import com.nextroom.nextroom.domain.repository.BillingRepository
@@ -14,5 +15,9 @@ class BillingRepositoryImpl @Inject constructor(
 
     override suspend fun getTickets(): Result<List<Ticket>> {
         return subscriptionDataSource.getTickets()
+    }
+
+    override suspend fun postPurchaseToken(purchaseToken: String): Result<Unit> {
+        return billingDataSource.postPurchaseToken(purchaseToken = PurchaseToken(purchaseToken))
     }
 }

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/BillingRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/BillingRepository.kt
@@ -4,6 +4,6 @@ import com.nextroom.nextroom.domain.model.Result
 import com.nextroom.nextroom.domain.model.Ticket
 
 interface BillingRepository {
-
     suspend fun getTickets(): Result<List<Ticket>>
+    suspend fun postPurchaseToken(purchaseToken: String): Result<Unit>
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/Constants.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/Constants.kt
@@ -1,8 +1,7 @@
 package com.nextroom.nextroom.presentation.ui
 
-// TODO JH: 서버에서 product ID 내려주면 파일 삭제
 object Constants {
-    //Product IDs
-    const val BASIC_PRODUCT = "1"
-    const val PREMIUM_PRODUCT = "2"
+    const val MINI_PRODUCT = "mini_subscription"
+    const val MEDIUM_PRODUCT = "medium_subscription"
+    const val LARGE_PRODUCT = "large_subscription"
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingViewModel.kt
@@ -100,7 +100,7 @@ class BillingViewModel
             BillingFlowParams.SubscriptionUpdateParams.newBuilder()
                 .setOldPurchaseToken(oldToken)
                 .setSubscriptionReplacementMode(
-                    BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_FULL_PRICE,
+                    BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.DEFERRED,
                 ).build(),
         ).build()
     }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/billing/BillingViewModel.kt
@@ -46,6 +46,7 @@ class BillingViewModel
             purchases.collect {
                 it.forEach { purchase ->
                     if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
+                        // TODO JH: 서버에서 ack 로직 구현 완료시 제거 + purchaseToken 보내는 API 호출
                         billingClientLifecycle.acknowledgePurchase(purchase.purchaseToken)
                     } else {
                         _uiEvent.emit(BillingEvent.PurchaseFailed(purchaseState = purchase.purchaseState))

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/purchase/PurchaseFragment.kt
@@ -74,8 +74,8 @@ class PurchaseFragment : BaseFragment<FragmentPurchaseBinding>(FragmentPurchaseB
     private fun handleEvent(event: PurchaseEvent) {
         when (event) {
             is PurchaseEvent.StartPurchase -> {
-                billingViewModel.buyBasePlans(
-                    product = event.productId,
+                billingViewModel.buyPlans(
+                    productId = event.productId,
                     tag = event.tag,
                     upDowngrade = event.upDowngrade,
                 )

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/util/BillingClientLifecycle.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/util/BillingClientLifecycle.kt
@@ -56,8 +56,9 @@ class BillingClientLifecycle private constructor(
     private var cachedPurchasesList: List<Purchase>? = null
 
     // 콘솔에 등록된 상품들 정보
-    val premiumSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
-    val basicSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
+    val largeSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
+    val mediumSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
+    val miniSubProductWithProductDetails = MutableLiveData<ProductDetails?>()
 
     private val _uiEvent = MutableSharedFlow<UIEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
@@ -167,10 +168,10 @@ class BillingClientLifecycle private constructor(
         productDetailsList.forEach { productDetails ->
             when (productDetails.productType) {
                 BillingClient.ProductType.SUBS -> {
-                    if (productDetails.productId == Constants.PREMIUM_PRODUCT) {
-                        premiumSubProductWithProductDetails.postValue(productDetails)
-                    } else if (productDetails.productId == Constants.BASIC_PRODUCT) {
-                        basicSubProductWithProductDetails.postValue(productDetails)
+                    when (productDetails.productId) {
+                        Constants.LARGE_PRODUCT -> largeSubProductWithProductDetails.postValue(productDetails)
+                        Constants.MEDIUM_PRODUCT -> mediumSubProductWithProductDetails.postValue(productDetails)
+                        Constants.MINI_PRODUCT -> miniSubProductWithProductDetails.postValue(productDetails)
                     }
                 }
             }
@@ -251,7 +252,7 @@ class BillingClientLifecycle private constructor(
             externalScope.launch {
                 val subscriptionPurchaseList = list.filter { purchase ->
                     purchase.products.any { product ->
-                        product in listOf(Constants.PREMIUM_PRODUCT, Constants.BASIC_PRODUCT)
+                        product in listOf(Constants.LARGE_PRODUCT, Constants.MEDIUM_PRODUCT, Constants.MINI_PRODUCT)
                     }
                 }
 
@@ -372,8 +373,9 @@ class BillingClientLifecycle private constructor(
         private const val MAX_RETRY_ATTEMPT = 3
 
         private val LIST_OF_SUBSCRIPTION_PRODUCTS = listOf(
-            Constants.BASIC_PRODUCT,
-            Constants.PREMIUM_PRODUCT,
+            Constants.MINI_PRODUCT,
+            Constants.MEDIUM_PRODUCT,
+            Constants.LARGE_PRODUCT,
         )
 
         @Volatile


### PR DESCRIPTION
## 작업 내용

1. ack 작업을 서버에서 하기로 하여
서버가 필요로 하는 purchaseToken을 전송하는 API를 연동해두었습니다.

2. 새로 설정한 구독 상품에 맞게 아이디를 설정하고
요금제를 구독할 수 있도록 코드를 변경했습니다.

3. 앱 내 ack 로직은 아직 삭제하지 않았습니다.
다른 브랜치에서 구독 결제 걷어낼 때 (주석이든 뭐든) 같이 작업할 예정입니다.

4. 요금제 변경시 정책을 deferred로 수정했습니다.
(저번에 수정하기로 했는데 아직 안바뀌어 있길래)

## 추가 안내

추후 이어서 작업하기 위해 일단 깃에 기록을 남기려고 PR을 올리는거고
이거 머지되고 나면 결제 관련한 것들 걷어내는 작업 따로 진행할 예정!