### PR TITLE
#54 feat: 타이머 시간 오차 버그 수정

### DIFF
--- a/data/src/main/java/com/nextroom/nextroom/data/model/GameStateEntity.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/model/GameStateEntity.kt
@@ -19,12 +19,10 @@ import com.nextroom.nextroom.domain.model.GameState
 )
 data class GameStateEntity(
     @PrimaryKey val playingThemeId: Int,
-    val playing: Boolean,
-    val timeLimit: Int,
-    val lastSeconds: Int,
+    val timeLimitInMinute: Int,
     val hintLimit: Int,
     val usedHints: Set<Int>,
-    val stoppedTime: Long, // 게임이 중단된 시간
+    val startTime: Long, // 게임을 시작한 시간
 ) {
     companion object {
         const val GAME_STATE_TABLE = "GameState"
@@ -32,14 +30,13 @@ data class GameStateEntity(
 }
 
 fun GameStateEntity.toDomain(): GameState {
-    val calibratedTime =
-        (lastSeconds - (System.currentTimeMillis() - stoppedTime) / 1000).coerceAtLeast(0).toInt()
+    val calibratedTime = (timeLimitInMinute * 60 - (System.currentTimeMillis() - startTime) / 1000).coerceAtLeast(0).toInt()
     return GameState(
         playingThemeId = playingThemeId,
-        playing = playing,
-        timeLimit = timeLimit,
+        timeLimitInMinute = timeLimitInMinute,
         lastSeconds = calibratedTime,
         hintLimit = hintLimit,
         usedHints = usedHints,
+        startTime = startTime,
     )
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/model/ThemeEntity.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/model/ThemeEntity.kt
@@ -11,7 +11,7 @@ data class ThemeEntity(
     @PrimaryKey val themeId: Int = 0,
     val adminCode: String = "00000",
     val title: String = "",
-    val timeLimit: Int = 3600,
+    val timeLimitInMinute: Int = 60,
     val hintLimit: Int = -1,
 ) {
     companion object {
@@ -23,7 +23,7 @@ fun ThemeEntity.toDomain(hints: List<Hint> = emptyList()): ThemeInfo {
     return ThemeInfo(
         id = themeId,
         title = title,
-        timeLimit = timeLimit,
+        timeLimitInMinute = timeLimitInMinute,
         hintLimit = hintLimit,
         hints = hints,
     )
@@ -38,7 +38,7 @@ fun ThemeInfo.toEntity(adminCode: String): ThemeEntity {
         themeId = id,
         adminCode = adminCode,
         title = title,
-        timeLimit = timeLimit * 60,
+        timeLimitInMinute = timeLimitInMinute,
         hintLimit = hintLimit,
     )
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/network/response/ThemeDto.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/network/response/ThemeDto.kt
@@ -23,7 +23,7 @@ fun ThemeDto.toDomain(hints: List<Hint> = emptyList()): ThemeInfo {
     return ThemeInfo(
         id = id,
         title = title,
-        timeLimit = timeLimit,
+        timeLimitInMinute = timeLimit,
         hintLimit = hintLimit,
         hints = hints,
     )

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/GameStateRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/GameStateRepositoryImpl.kt
@@ -14,23 +14,22 @@ class GameStateRepositoryImpl @Inject constructor(
     private val timerRepository: TimerRepository,
     private val gameStateDao: GameStateDao,
 ) : GameStateRepository {
-    override suspend fun saveGameState(playing: Boolean, timeLimit: Int, lastSeconds: Int, hintLimit: Int, usedHints: Set<Int>) {
+    override suspend fun saveGameState(
+        timeLimitInMinute: Int,
+        hintLimit: Int,
+        usedHints: Set<Int>,
+        startTime: Long,
+    ) {
         val themeId = settingDataSource.getLatestGameCode()
-        if (playing) {
-            gameStateDao.insertGameState(
-                GameStateEntity(
-                    playingThemeId = themeId,
-                    playing = true,
-                    timeLimit = timeLimit,
-                    lastSeconds = lastSeconds,
-                    hintLimit = hintLimit,
-                    usedHints = usedHints,
-                    stoppedTime = System.currentTimeMillis(),
-                ),
-            )
-        } else {
-            finishGame()
-        }
+        gameStateDao.insertGameState(
+            GameStateEntity(
+                playingThemeId = themeId,
+                timeLimitInMinute = timeLimitInMinute,
+                hintLimit = hintLimit,
+                usedHints = usedHints,
+                startTime = startTime,
+            ),
+        )
     }
 
     override suspend fun finishGame(onFinished: () -> Unit) {

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/TimerRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/TimerRepositoryImpl.kt
@@ -31,9 +31,9 @@ class TimerRepositoryImpl @Inject constructor(
     private var _lastMillis = MutableStateFlow(0L)
     override val lastSeconds: Flow<Int> = _lastMillis.map { (it / 1000).toInt() }
 
-    override fun initTimer(initSeconds: Int) {
-        Timber.d("initTimer")
-        _lastMillis.value = initSeconds * 1000L
+    override fun setTimer(seconds: Int) {
+        Timber.d("setTimer")
+        _lastMillis.value = seconds * 1000L
         setTimerState(TimerState.Ready)
     }
 

--- a/domain/src/main/java/com/nextroom/nextroom/domain/model/GameState.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/model/GameState.kt
@@ -2,8 +2,8 @@ package com.nextroom.nextroom.domain.model
 
 data class GameState(
     val playingThemeId: Int,
-    val playing: Boolean,
-    val timeLimit: Int,
+    val timeLimitInMinute: Int, // ex) 60 = 60분
+    val startTime: Long,
     val lastSeconds: Int, // 보정된 시간
     val hintLimit: Int,
     val usedHints: Set<Int>,

--- a/domain/src/main/java/com/nextroom/nextroom/domain/model/ThemeInfo.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/model/ThemeInfo.kt
@@ -3,7 +3,7 @@ package com.nextroom.nextroom.domain.model
 data class ThemeInfo(
     val id: Int = 0,
     val title: String = "",
-    val timeLimit: Int = 3600,
+    val timeLimitInMinute: Int = 60,
     val hintLimit: Int = -1,
     val hints: List<Hint> = emptyList(),
 )

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/GameStateRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/GameStateRepository.kt
@@ -5,7 +5,7 @@ import com.nextroom.nextroom.domain.model.GameState
 interface GameStateRepository {
 
     suspend fun saveGameState(
-        timeLimit: Int,
+        timeLimitInMinute: Int,
         hintLimit: Int,
         usedHints: Set<Int>,
         startTime: Long,

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/GameStateRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/GameStateRepository.kt
@@ -5,11 +5,10 @@ import com.nextroom.nextroom.domain.model.GameState
 interface GameStateRepository {
 
     suspend fun saveGameState(
-        playing: Boolean,
         timeLimit: Int,
-        lastSeconds: Int,
         hintLimit: Int,
         usedHints: Set<Int>,
+        startTime: Long,
     )
 
     suspend fun finishGame(onFinished: () -> Unit = {})

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/TimerRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/TimerRepository.kt
@@ -7,14 +7,13 @@ import kotlinx.coroutines.flow.StateFlow
 interface TimerRepository {
     val lastSeconds: Flow<Int>
     val timerState: StateFlow<TimerState>
-    fun setTimer(seconds: Int)
-    fun startTimer()
-    fun stopTimer()
 
     /**
-     * 시간 보정
+     * 시스템 시간을 기반으로 하는 타이머
      *
-     * @param milliseconds 보정할 시간(밀리초). 양수이면 남은 시간에 더해지고, 음수이면 남은 시간에서 차감됨.
+     * @param endTimeMillis 종료될 시각의 밀리초 (시작 시각 밀리초 + 플레이 시간(분) * 60 * 1000)
      */
-    fun correctTime(milliseconds: Long)
+    fun startTimerUntil(endTimeMillis: Long)
+
+    fun stopTimer()
 }

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/TimerRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/TimerRepository.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 interface TimerRepository {
     val lastSeconds: Flow<Int>
     val timerState: StateFlow<TimerState>
-    fun initTimer(initSeconds: Int)
+    fun setTimer(seconds: Int)
     fun startTimer()
     fun stopTimer()
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/customview/ArcProgressView.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/customview/ArcProgressView.kt
@@ -69,7 +69,7 @@ class ArcProgressView @JvmOverloads constructor(
     private val defaultStrokeWidth: Float = 6.dp.toFloat()
     private val defaultTextSize: Float = 56.dp.toFloat()
 
-    var timeLimit = 3600
+    var timeLimit = 0
         set(value) {
             if (value > 0) {
                 field = value

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/model/ThemeInfoPresentation.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/model/ThemeInfoPresentation.kt
@@ -6,7 +6,7 @@ import com.nextroom.nextroom.domain.model.ThemeInfo
 data class ThemeInfoPresentation(
     val id: Int = 0,
     val title: String = "",
-    val timeLimit: Int = 3600,
+    val timeLimit: Int = 0,
     val hintLimit: Int = -1,
     val hints: List<Hint> = emptyList(),
     val recentUpdated: Long = 0L,
@@ -16,7 +16,7 @@ fun ThemeInfo.toPresentation(recentUpdated: Long): ThemeInfoPresentation {
     return ThemeInfoPresentation(
         id = id,
         title = title,
-        timeLimit = timeLimit,
+        timeLimit = timeLimitInMinute,
         hintLimit = hintLimit,
         hints = hints,
         recentUpdated = recentUpdated,

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainViewModel.kt
@@ -36,9 +36,7 @@ class MainViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             gameStateRepository.getGameState()?.let { gameState ->
-                if (gameState.playing) {
-                    event(MainEvent.GoToGameScreen(gameState))
-                }
+                event(MainEvent.GoToGameScreen(gameState))
             }
         }
         viewModelScope.launch {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
@@ -59,9 +59,9 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
         }
     }*/
 
-    private fun startGame(code: Int) {
-        viewModel.start(code) {
-            goToCounter()
+    private fun startGame(themeId: Int) {
+        viewModel.start(themeId) {
+            goToMain()
         }
     }
 
@@ -111,7 +111,7 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
         findNavController().safeNavigate(action)
     }
 
-    private fun goToCounter() {
+    private fun goToMain() {
         val action = AdminMainFragmentDirections.actionAdminMainFragmentToVerifyFragment()
         findNavController().safeNavigate(action)
     }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
@@ -61,7 +61,7 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
 
     private fun startGame(themeId: Int) {
         viewModel.start(themeId) {
-            goToMain()
+            goToMain(themeId)
         }
     }
 
@@ -111,8 +111,8 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
         findNavController().safeNavigate(action)
     }
 
-    private fun goToMain() {
-        val action = AdminMainFragmentDirections.actionAdminMainFragmentToVerifyFragment()
+    private fun goToMain(themeId: Int) {
+        val action = AdminMainFragmentDirections.actionAdminMainFragmentToVerifyFragment(themeId = themeId)
         findNavController().safeNavigate(action)
     }
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.viewModelScope
 import com.nextroom.nextroom.domain.model.onSuccess
 import com.nextroom.nextroom.domain.repository.AdminRepository
 import com.nextroom.nextroom.domain.repository.DataStoreRepository
-import com.nextroom.nextroom.domain.repository.GameStateRepository
 import com.nextroom.nextroom.domain.repository.HintRepository
 import com.nextroom.nextroom.domain.repository.ThemeRepository
 import com.nextroom.nextroom.presentation.base.BaseViewModel
@@ -26,7 +25,6 @@ class AdminMainViewModel @Inject constructor(
     private val themeRepository: ThemeRepository,
     private val hintRepository: HintRepository,
     private val dataStoreRepository: DataStoreRepository,
-    private val gameStateRepository: GameStateRepository,
 ) : BaseViewModel<AdminMainState, Nothing>() {
 
     override val container: Container<AdminMainState, Nothing> = container(AdminMainState(loading = true))
@@ -57,18 +55,6 @@ class AdminMainViewModel @Inject constructor(
 
     fun start(themeId: Int, readyToStart: () -> Unit) = intent {
         themeRepository.updateLatestTheme(themeId)
-
-        state
-            .themes
-            .find { it.id == themeId }
-            ?.also {
-                gameStateRepository.saveGameState(
-                    timeLimit = it.timeLimit,
-                    hintLimit = it.hintLimit,
-                    usedHints = emptySet(),
-                    startTime = System.currentTimeMillis(),
-                )
-            }
         withContext(Dispatchers.Main) {
             readyToStart()
         }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.nextroom.nextroom.domain.model.onSuccess
 import com.nextroom.nextroom.domain.repository.AdminRepository
 import com.nextroom.nextroom.domain.repository.DataStoreRepository
+import com.nextroom.nextroom.domain.repository.GameStateRepository
 import com.nextroom.nextroom.domain.repository.HintRepository
 import com.nextroom.nextroom.domain.repository.ThemeRepository
 import com.nextroom.nextroom.presentation.base.BaseViewModel
@@ -25,6 +26,7 @@ class AdminMainViewModel @Inject constructor(
     private val themeRepository: ThemeRepository,
     private val hintRepository: HintRepository,
     private val dataStoreRepository: DataStoreRepository,
+    private val gameStateRepository: GameStateRepository,
 ) : BaseViewModel<AdminMainState, Nothing>() {
 
     override val container: Container<AdminMainState, Nothing> = container(AdminMainState(loading = true))
@@ -55,6 +57,18 @@ class AdminMainViewModel @Inject constructor(
 
     fun start(themeId: Int, readyToStart: () -> Unit) = intent {
         themeRepository.updateLatestTheme(themeId)
+
+        state
+            .themes
+            .find { it.id == themeId }
+            ?.also {
+                gameStateRepository.saveGameState(
+                    timeLimit = it.timeLimit,
+                    hintLimit = it.hintLimit,
+                    usedHints = emptySet(),
+                    startTime = System.currentTimeMillis(),
+                )
+            }
         withContext(Dispatchers.Main) {
             readyToStart()
         }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/counter/CounterFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/counter/CounterFragment.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
-import com.nextroom.nextroom.domain.model.TimerState
 import com.nextroom.nextroom.presentation.base.BaseFragment
 import com.nextroom.nextroom.presentation.databinding.FragmentStartTimerBinding
 import com.nextroom.nextroom.presentation.extension.enableFullScreen
@@ -34,10 +32,10 @@ class CounterFragment : BaseFragment<FragmentStartTimerBinding>(FragmentStartTim
     private fun render(state: CounterState) = with(binding) {
         tvLastSeconds.text = state.lastSeconds.toString()
 
-        if (state.timerState is TimerState.Finished) {
-            val overflowTime = viewModel.getOverflowTimeMillis()
-            val action = CounterFragmentDirections.actionStartTimerFragmentToMainFragment(overflowTime)
-            findNavController().navigate(action)
-        }
+//        if (state.timerState is TimerState.Finished) {
+//            val overflowTime = viewModel.getOverflowTimeMillis()
+//            val action = CounterFragmentDirections.actionStartTimerFragmentToMainFragment(overflowTime)
+//            findNavController().navigate(action)
+//        }
     }
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/login/LoginEvent.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/login/LoginEvent.kt
@@ -6,4 +6,5 @@ sealed interface LoginEvent {
     data class LoginFailed(val message: String) : LoginEvent
     data class ShowMessage(val message: UiText) : LoginEvent
     data object GoToOnboardingScreen : LoginEvent
+    data object GoToMainScreen : LoginEvent
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/login/LoginFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/login/LoginFragment.kt
@@ -103,6 +103,8 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>(FragmentLoginBinding::i
             LoginEvent.GoToOnboardingScreen -> {
                 goToOnboardingScreen()
             }
+
+            LoginEvent.GoToMainScreen -> Unit
         }
     }
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameEvent.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameEvent.kt
@@ -8,4 +8,5 @@ sealed interface GameEvent {
     ) : GameEvent
 
     data object GameFinish : GameEvent
+    data object ClearHintCode : GameEvent
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameEvent.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameEvent.kt
@@ -6,4 +6,6 @@ sealed interface GameEvent {
     data class OnOpenHint(
         val hint: Hint,
     ) : GameEvent
+
+    data object GameFinish : GameEvent
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
@@ -45,12 +45,6 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
         viewModel.observe(viewLifecycleOwner, state = ::render, sideEffect = ::handleEvent)
     }
 
-    override fun onResume() {
-        super.onResume()
-
-        viewModel.startOrResumeGame()
-    }
-
     private fun initViews() = with(binding) {
         tbGame.apply {
             root.setBackgroundColor(resources.getColor(android.R.color.transparent, null))
@@ -141,11 +135,6 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
 
     private fun vibrate() {
         requireContext().vibrator.vibrate(longArrayOf(100, 100, 100, 100), -1)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        viewModel.setGameState()
     }
 
     override fun onDetach() {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
@@ -14,6 +14,7 @@ import com.nextroom.nextroom.presentation.databinding.FragmentMainBinding
 import com.nextroom.nextroom.presentation.extension.enableFullScreen
 import com.nextroom.nextroom.presentation.extension.safeNavigate
 import com.nextroom.nextroom.presentation.extension.setOnLongClickListener
+import com.nextroom.nextroom.presentation.extension.snackbar
 import com.nextroom.nextroom.presentation.extension.toTimeUnit
 import com.nextroom.nextroom.presentation.extension.vibrator
 import com.nextroom.nextroom.presentation.model.InputState
@@ -42,6 +43,12 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
 
         initViews()
         viewModel.observe(viewLifecycleOwner, state = ::render, sideEffect = ::handleEvent)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        viewModel.startOrResumeGame()
     }
 
     private fun initViews() = with(binding) {
@@ -134,6 +141,11 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
 
     private fun vibrate() {
         requireContext().vibrator.vibrate(longArrayOf(100, 100, 100, 100), -1)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.setGameState()
     }
 
     override fun onDetach() {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
@@ -95,6 +95,8 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
                 findNavController().safeNavigate(action)
                 clearHintCode()
             }
+
+            GameEvent.GameFinish -> snackbar("게임이 종료되었습니다")
         }
     }
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameFragment.kt
@@ -91,13 +91,14 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
 
     private fun handleEvent(event: GameEvent) {
         when (event) {
+            is GameEvent.ClearHintCode -> binding.customCodeInput.setCode("")
             is GameEvent.OnOpenHint -> {
                 val action = GameFragmentDirections.actionMainFragmentToHintFragment(event.hint)
                 findNavController().safeNavigate(action)
-                clearHintCode()
+                viewModel.clearHintCode()
             }
 
-            GameEvent.GameFinish -> snackbar("게임이 종료되었습니다")
+            is GameEvent.GameFinish -> snackbar(R.string.game_finished)
         }
     }
 
@@ -126,11 +127,6 @@ class GameFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
         tvKey9.setOnClickListener { viewModel.inputHintCode(9) }
         tvKey0.setOnClickListener { viewModel.inputHintCode(0) }
         keyBackspace.setOnClickListener { viewModel.backspaceHintCode() }
-    }
-
-    private fun clearHintCode() {
-        viewModel.clearHintCode()
-        binding.customCodeInput.setCode("")
     }
 
     private fun vibrate() {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameScreenState.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameScreenState.kt
@@ -10,6 +10,7 @@ data class GameScreenState(
     val usedHints: Set<Int> = emptySet(),
     val answerOpenedHints: Set<Int> = emptySet(),
     val totalHintCount: Int = -1,
+    val startTime: Long = -1,
 ) {
     val usedHintsCount: Int
         get() = usedHints.size

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameViewModel.kt
@@ -107,6 +107,11 @@ class GameViewModel @Inject constructor(
     }
 
     private fun validateHintCode() = intent {
+        if (timerRepository.timerState.value is TimerState.Finished) {
+            postSideEffect(GameEvent.GameFinish)
+            return@intent
+        }
+
         hintRepository.getHint(state.currentInput)?.let { hint ->
             reduce {
                 state.copy(

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyFragment.kt
@@ -6,6 +6,7 @@ import android.view.inputmethod.EditorInfo
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.nextroom.nextroom.presentation.base.BaseFragment
 import com.nextroom.nextroom.presentation.databinding.FragmentAdminCodeBinding
 import com.nextroom.nextroom.presentation.extension.safeNavigate
@@ -21,6 +22,7 @@ import org.orbitmvi.orbit.viewmodel.observe
 class VerifyFragment : BaseFragment<FragmentAdminCodeBinding>(FragmentAdminCodeBinding::inflate) {
 
     private val viewModel: VerifyViewModel by viewModels()
+    private val args: VerifyFragmentArgs by navArgs()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -56,8 +58,7 @@ class VerifyFragment : BaseFragment<FragmentAdminCodeBinding>(FragmentAdminCodeB
 
     private fun render(state: VerifyState) = with(binding) {
         if (state.inputState is InputState.Ok) {
-            val action = VerifyFragmentDirections.actionVerifyFragmentToMainFragment()
-            findNavController().safeNavigate(action)
+            viewModel.startGame(themeId = args.themeId)
         }
         btnInput.isEnabled = state.currentInput.length == 5
     }
@@ -67,6 +68,10 @@ class VerifyFragment : BaseFragment<FragmentAdminCodeBinding>(FragmentAdminCodeB
             is LoginEvent.LoginFailed -> snackbar(event.message)
             is LoginEvent.ShowMessage -> snackbar(event.message.toString(requireContext()))
             LoginEvent.GoToOnboardingScreen -> Unit
+            LoginEvent.GoToMainScreen -> {
+                val action = VerifyFragmentDirections.actionVerifyFragmentToMainFragment()
+                findNavController().safeNavigate(action)
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyFragment.kt
@@ -56,7 +56,7 @@ class VerifyFragment : BaseFragment<FragmentAdminCodeBinding>(FragmentAdminCodeB
 
     private fun render(state: VerifyState) = with(binding) {
         if (state.inputState is InputState.Ok) {
-            val action = VerifyFragmentDirections.actionVerifyFragmentToStartTimerFragment()
+            val action = VerifyFragmentDirections.actionVerifyFragmentToMainFragment()
             findNavController().safeNavigate(action)
         }
         btnInput.isEnabled = state.currentInput.length == 5

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyViewModel.kt
@@ -1,13 +1,22 @@
 package com.nextroom.nextroom.presentation.ui.verity
 
 import androidx.annotation.StringRes
+import androidx.lifecycle.viewModelScope
+import com.nextroom.nextroom.domain.model.onSuccess
 import com.nextroom.nextroom.domain.repository.AdminRepository
+import com.nextroom.nextroom.domain.repository.GameStateRepository
+import com.nextroom.nextroom.domain.repository.ThemeRepository
 import com.nextroom.nextroom.presentation.R
 import com.nextroom.nextroom.presentation.base.BaseViewModel
 import com.nextroom.nextroom.presentation.model.InputState
+import com.nextroom.nextroom.presentation.model.ThemeInfoPresentation
 import com.nextroom.nextroom.presentation.model.UiText
+import com.nextroom.nextroom.presentation.model.toPresentation
 import com.nextroom.nextroom.presentation.ui.login.LoginEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -18,8 +27,25 @@ import javax.inject.Inject
 @HiltViewModel
 class VerifyViewModel @Inject constructor(
     private val adminRepository: AdminRepository,
+    private val themeRepository: ThemeRepository,
+    private val gameStateRepository: GameStateRepository,
 ) : BaseViewModel<VerifyState, LoginEvent>() { // TODO: LoginEvent 사용 하지 말고 따로 Event 분리 하기
     override val container: Container<VerifyState, LoginEvent> = container(VerifyState())
+
+    private val themes = MutableStateFlow<List<ThemeInfoPresentation>>(emptyList())
+    val _themes = themes.asStateFlow()
+
+    init {
+        fetchThemes()
+    }
+
+    private fun fetchThemes() {
+        viewModelScope.launch {
+            themeRepository.getThemes().onSuccess {
+                themes.emit(it.map { it.toPresentation(System.currentTimeMillis()) })
+            }
+        }
+    }
 
     fun inputCode(code: String) = intent {
         reduce {
@@ -38,6 +64,23 @@ class VerifyViewModel @Inject constructor(
         val success = adminRepository.verifyAdminCode(state.currentInput)
         reduce {
             state.copy(inputState = if (success) InputState.Ok else InputState.Error(R.string.blank))
+        }
+    }
+
+    fun startGame(themeId: Int) = intent {
+        viewModelScope.launch {
+            themes
+                .value
+                .find { it.id == themeId }
+                ?.also {
+                    gameStateRepository.saveGameState(
+                        timeLimit = it.timeLimit,
+                        hintLimit = it.hintLimit,
+                        usedHints = emptySet(),
+                        startTime = System.currentTimeMillis(),
+                    )
+                    postSideEffect(LoginEvent.GoToMainScreen)
+                }
         }
     }
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/verity/VerifyViewModel.kt
@@ -74,7 +74,7 @@ class VerifyViewModel @Inject constructor(
                 .find { it.id == themeId }
                 ?.also {
                     gameStateRepository.saveGameState(
-                        timeLimit = it.timeLimit,
+                        timeLimitInMinute = it.timeLimit,
                         hintLimit = it.hintLimit,
                         usedHints = emptySet(),
                         startTime = System.currentTimeMillis(),

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -50,20 +50,23 @@
         android:name="com.nextroom.nextroom.presentation.ui.verity.VerifyFragment"
         android:label="VerifyFragment"
         tools:layout="@layout/fragment_admin_code">
+<!--        <action-->
+<!--            android:id="@+id/action_verifyFragment_to_startTimerFragment"-->
+<!--            app:destination="@id/startTimerFragment" />-->
         <action
-            android:id="@+id/action_verifyFragment_to_startTimerFragment"
-            app:destination="@id/startTimerFragment" />
+            android:id="@+id/action_verifyFragment_to_mainFragment"
+            app:destination="@id/mainFragment" />
     </fragment>
-    <fragment
-        android:id="@+id/startTimerFragment"
-        android:name="com.nextroom.nextroom.presentation.ui.counter.CounterFragment"
-        android:label="StartTimerFragment"
-        tools:layout="@layout/fragment_start_timer">
-        <action
-            android:id="@+id/action_startTimerFragment_to_mainFragment"
-            app:destination="@id/mainFragment"
-            app:popUpTo="@id/adminMainFragment" />
-    </fragment>
+<!--    <fragment-->
+<!--        android:id="@+id/startTimerFragment"-->
+<!--        android:name="com.nextroom.nextroom.presentation.ui.counter.CounterFragment"-->
+<!--        android:label="StartTimerFragment"-->
+<!--        tools:layout="@layout/fragment_start_timer">-->
+<!--        <action-->
+<!--            android:id="@+id/action_startTimerFragment_to_mainFragment"-->
+<!--            app:destination="@id/mainFragment"-->
+<!--            app:popUpTo="@id/adminMainFragment" />-->
+<!--    </fragment>-->
     <fragment
         android:id="@+id/hintFragment"
         android:name="com.nextroom.nextroom.presentation.ui.hint.HintFragment"

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -24,7 +24,12 @@
         tools:layout="@layout/fragment_admin_main">
         <action
             android:id="@+id/action_adminMainFragment_to_verifyFragment"
-            app:destination="@id/verifyFragment" />
+            app:destination="@id/verifyFragment">
+
+            <argument
+                android:name="themeId"
+                app:argType="integer"/>
+        </action>
         <action
             android:id="@+id/action_adminMainFragment_to_mypageFragment"
             app:destination="@id/mypageFragment" />
@@ -50,12 +55,17 @@
         android:name="com.nextroom.nextroom.presentation.ui.verity.VerifyFragment"
         android:label="VerifyFragment"
         tools:layout="@layout/fragment_admin_code">
+
+        <argument
+            android:name="themeId"
+            app:argType="integer"/>
 <!--        <action-->
 <!--            android:id="@+id/action_verifyFragment_to_startTimerFragment"-->
 <!--            app:destination="@id/startTimerFragment" />-->
         <action
             android:id="@+id/action_verifyFragment_to_mainFragment"
-            app:destination="@id/mainFragment" />
+            app:destination="@id/mainFragment"
+            app:popUpTo="@id/adminMainFragment" />
     </fragment>
 <!--    <fragment-->
 <!--        android:id="@+id/startTimerFragment"-->

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
 
     <string name="game_main_exit_dialog">방탈출을 종료하시겠습니까?</string>
     <string name="game_main_exit_dialog_message">종료하시면 모든 기록은 초기화됩니다.</string>
+    <string name="game_finished">게임이 종료되었습니다</string>
     <string name="game_view_hint">힌트 보기</string>
     <string name="game_wrong_hint_code">힌트 코드를 잘못 입력했습니다</string>
     <string name="game_hint_code_label">Hint Code</string>


### PR DESCRIPTION
-close #54 

[정책 변경]
- 카운터 프래그먼트 사용하지 않음
   - 사장님들과 알바생의 의견 반영
   - 이번에 작업하는데 걸림돌이 되어서 같이 작업함
   - 추후에 옵션으로 제공할 수 있지 않을까 하여 삭제까진 하지 않았고 주석처리만 함
- 게임 종료시 힌트 사용하지 못하도록 수정
   - 스낵바를 띄우며 게임이 종료되었다고 안내
- 게임 상태 저장 시점, 주기 변경
   - 기존에는 1초마다 저장하였으나, 화면을 벗어날 때 게임 상태를 저장하고 돌아올 때 복구하도록 수정
   - 앱을 단순히 닫고 돌아왔을 때나 메모장을 갔다가 돌아왔을 때도 복구함. (플레이시간 복구가 주 목적)


[변수 변경]
- isPlaying 제거
as-is: gameState를 저장할 때 직전에 플레이 중이였는지 isPlaying을 저장. 게임에 다시 진입할때 이를 통해 데이터를 복구할지 결정
to-be: gameState가 있으면 데이터 복구, 없으면 게임 끝난것으로 간주 (굳이 isPlaying을 저장할 필요없다고 생각함)

- stoppedTime
as-is: 1초마다 현재 시간을 저장함. 데이터 복구시 가장 마지막에 저장한 stoppedTime으로 시간 계산
to-be: 게임을 맨 처음 시작할때 startTime을 저장. 데이터 복구시 startTime으로 시간 계산

- timeLimit
as-is: 서버에서는 분 단위로 데이터를 내려주고 db에는 초 단위로 저장하는데 두 변수의 이름이 같아서 다소 혼란스러움
to-be: 분 단위로 통일. 변수 이름을 좀 더 명확하게 timeLimitInMinute으로 변경


[의견]
TimerRepositoryImpl의 startTimer를 보니까
while문이 0.001초마다 반복해서 돌고 있더라고
이 부분도 성능에 영향을 줄 수 있지 않을까 싶은데 0.1초에 한 번 정도로 하는건 어떨까?


[기타]
아직 고치고 싶은 부분도 많이 보이고
내가 이번에 짠 코드도 맘에 안드는 부분 많은데
한 번에 다 안고가자니 작업이 너무 커지고 CS 대응이 늦어질 것 같아 ..

이렇게 짜면 더 좋겠는데? 보다는
이거 이렇게 하면 문제 있겠는데? 싶은 부분 위주로 리뷰 부탁드립니다

+) 원래는 60분짜리 게임이면 20분까지 차이나고 했는데 현재는 1분정도 차이나는듯
정확한 1초 카운트가 안돼서 계속 조금씩 차이가 나
이것도 추후 해결해야 하는 부분...