### PR TITLE
#57 fix: 게임 정보 업데이트 후 갱신 안되는 문제 해결

### DIFF
--- a/data/src/main/java/com/nextroom/nextroom/data/datasource/ThemeLocalDataSource.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/datasource/ThemeLocalDataSource.kt
@@ -30,6 +30,10 @@ class ThemeLocalDataSource @Inject constructor(
         themeDao.insertThemes(*newData)
     }
 
+    suspend fun upsertTheme(adminCode: String, themeInfo: ThemeInfo) {
+        themeDao.insertTheme(themeInfo.toEntity(adminCode))
+    }
+
     suspend fun getTheme(themeId: Int): Flow<ThemeInfo> {
         return themeDao.getTheme(themeId).map {
             val hints = hintDao.getHints(it.themeId)

--- a/data/src/main/java/com/nextroom/nextroom/data/db/NextRoomDatabase.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/NextRoomDatabase.kt
@@ -12,7 +12,7 @@ import com.nextroom.nextroom.data.model.ThemeTimeEntity
 
 @Database(
     entities = [ThemeEntity::class, ThemeTimeEntity::class, HintEntity::class, GameStateEntity::class, GameStatsEntity::class, HintStatsEntity::class],
-    version = 1,
+    version = 2,
 )
 @TypeConverters(TypeConverter::class)
 abstract class NextRoomDatabase : RoomDatabase() {

--- a/data/src/main/java/com/nextroom/nextroom/data/db/ThemeDao.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/ThemeDao.kt
@@ -17,7 +17,7 @@ interface ThemeDao {
     @Query("SELECT * FROM $THEME_TABLE_NAME WHERE themeId = :themeId LIMIT 1")
     fun getTheme(themeId: Int): Flow<ThemeEntity>
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertThemes(vararg themes: ThemeEntity)
 
     @Query("DELETE FROM $THEME_TABLE_NAME WHERE adminCode = :adminCode")

--- a/data/src/main/java/com/nextroom/nextroom/data/db/ThemeDao.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/ThemeDao.kt
@@ -20,6 +20,9 @@ interface ThemeDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertThemes(vararg themes: ThemeEntity)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTheme(theme: ThemeEntity)
+
     @Query("DELETE FROM $THEME_TABLE_NAME WHERE adminCode = :adminCode")
     suspend fun deleteThemes(adminCode: String)
 }

--- a/data/src/main/java/com/nextroom/nextroom/data/model/ThemeTimeEntity.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/model/ThemeTimeEntity.kt
@@ -11,7 +11,7 @@ import com.nextroom.nextroom.data.model.ThemeTimeEntity.Companion.THEME_TIME_TAB
             entity = ThemeEntity::class,
             parentColumns = arrayOf("themeId"),
             childColumns = arrayOf("themeId"),
-            onDelete = ForeignKey.CASCADE,
+            onDelete = ForeignKey.NO_ACTION,
         ),
     ],
     primaryKeys = ["themeId", "recentUpdated"],

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/ThemeRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/ThemeRepositoryImpl.kt
@@ -31,6 +31,13 @@ class ThemeRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun upsertTheme(themeInfo: ThemeInfo) {
+        themeLocalDataSource.upsertTheme(
+            adminCode = settingDataSource.getAdminCode(),
+            themeInfo = themeInfo,
+        )
+    }
+
     override suspend fun updateLatestTheme(themeId: Int) {
         settingDataSource.setLatestGameCode(themeId)
         themeLocalDataSource.updatePlayedInfo(themeId, System.currentTimeMillis())

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/ThemeRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/ThemeRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 interface ThemeRepository {
     suspend fun getLocalThemes(): Flow<List<ThemeInfo>> // 전체 테마 목록 호출
     suspend fun getThemes(): Result<List<ThemeInfo>>
+    suspend fun upsertTheme(themeInfo: ThemeInfo)
     suspend fun updateLatestTheme(themeId: Int) // 최근 플레이 한 테마 갱신
     suspend fun getLatestTheme(): Flow<ThemeInfo> // 최근 플레이 한 테마
     suspend fun getUpdatedInfo(themeId: Int): Long // 최근 업데이트 날짜 (Long)

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainFragment.kt
@@ -26,7 +26,7 @@ class AdminMainFragment : BaseFragment<FragmentAdminMainBinding>(FragmentAdminMa
     private val adapter: ThemesAdapter by lazy {
         ThemesAdapter(
             onStartGame = ::startGame,
-            onClickUpdate = viewModel::updateHints,
+            onClickUpdate = viewModel::updateTheme,
         )
     }
 

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
@@ -42,7 +42,15 @@ class AdminMainViewModel @Inject constructor(
         }
     }
 
-    fun updateHints(themeId: Int) = intent {
+    fun updateTheme(themeId: Int) = intent {
+        themeRepository
+            .getThemes()
+            .onSuccess { themes ->
+                themes
+                    .find { it.id == themeId }
+                    ?.let { themeRepository.upsertTheme(it) }
+            }
+
         hintRepository.saveHints(themeId).onSuccess { updatedAt ->
             reduce {
                 state.copy(


### PR DESCRIPTION
-close #57 

## 문제

백오피스에서 게임 정보 수정 후에도 반영되지 않는 문제

## 원인

동일한 테마(게임) id 를 insert 할 때 IGNORE 옵션으로 되어있어서 게임 정보 수정 후에도 반영되지 않았던 것으로 추측됨

정확한 테스트를 위해서는 백오피스에서 수정 후 반영되는지 확인 필요!

## 해결

REPLACE 옵션으로 변경
