### PR TITLE
#66 chore: allowBackup 비활성화

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
     <application
         android:name="com.nextroom.nextroom.NextRoomApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## AS-IS

[크래시 발생](https://play.google.com/console/u/0/developers/5165094665482396075/app/4974200689524261173/vitals/crashes/36d634f962c34dd0b8d462eef896368d/details?days=28&versionCode=37&isUserPerceived=true)의 원인으로 `allowBackup` 옵션이 의심되어 비활성화 처리 필요

## TO-BE

manifest 의 `allowBackup` 옵션 비활성화 처리.

확실한 해결 방법인지는 모르겠음. 다만 현재 코드에서 발생할 수 없는 오류라 생각돼서 유력한 범인으로 생각됨.

앱 삭제 후 재설치 했을 때 굳이 이전의 데이터를 복원해주기 보다는 이러한 오류가 발생할 확률을 줄이는 것이 더 좋을 것이라 판단되고, 앱을 사용하는데 영향이 거의 없을 것이라 비활성화 해도 무방할 듯.

## 참고

[Hilt 와 allowBackup 에 관련된 스택오버플로우](https://stackoverflow.com/questions/72224270/android-hilt-throw-illegalstateexception-even-stated-custom-application-in-manif)

[공식 문서](https://developer.android.com/guide/topics/data/autobackup?hl=ko)
