### PR TITLE
#74 feat: 다이얼로그 띄워진 화면 안정성 개선

### DIFF
--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/base/BaseDialogFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/base/BaseDialogFragment.kt
@@ -1,0 +1,38 @@
+package com.nextroom.nextroom.presentation.base
+
+import android.app.ActionBar
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.viewbinding.ViewBinding
+
+abstract class BaseDialogFragment<VB : ViewBinding>(private val inflate: Inflate<VB>) : DialogFragment() {
+    private var _binding: VB? = null
+    val binding: VB
+        get() = checkNotNull(_binding) { "binding is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        _binding = inflate.invoke(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        dialog?.window?.setLayout(
+            ActionBar.LayoutParams.MATCH_PARENT,
+            ActionBar.LayoutParams.WRAP_CONTENT,
+        )
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/common/NRTwoButtonDialog.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/common/NRTwoButtonDialog.kt
@@ -1,0 +1,64 @@
+package com.nextroom.nextroom.presentation.common
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.InsetDrawable
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.setFragmentResult
+import androidx.navigation.fragment.navArgs
+import com.nextroom.nextroom.presentation.base.BaseDialogFragment
+import com.nextroom.nextroom.presentation.databinding.DialogFragmentNrTwoButtonBinding
+import com.nextroom.nextroom.presentation.extension.dp
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
+
+@AndroidEntryPoint
+class NRTwoButtonDialog :
+    BaseDialogFragment<DialogFragmentNrTwoButtonBinding>(DialogFragmentNrTwoButtonBinding::inflate) {
+
+    private val args: NRTwoButtonDialogArgs by navArgs()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val bg = InsetDrawable(ColorDrawable(Color.TRANSPARENT), 36.dp)
+        dialog?.window?.setBackgroundDrawable(bg)
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(args.nrTwoButtonArgument) {
+            binding.tvTitle.text = title
+            binding.tvMessage.text = message
+            binding.btnPositive.text = posBtnText
+            binding.btnNegative.text = negBtnText
+        }
+
+        initListeners()
+    }
+
+    private fun initListeners() {
+        binding.btnPositive.setOnClickListener {
+            dismiss()
+            setFragmentResult(args.nrTwoButtonArgument.dialogKey, bundleOf())
+        }
+        binding.btnNegative.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    @Parcelize
+    data class NRTwoButtonArgument(
+        val title: String,
+        val message: String,
+        val isCancelable: Boolean = false,
+        val posBtnText: String? = null,
+        val negBtnText: String? = null,
+        val dialogKey: String,
+    ) : Parcelable
+}

--- a/presentation/src/main/res/layout/dialog_fragment_nr_two_button.xml
+++ b/presentation/src/main/res/layout/dialog_fragment_nr_two_button.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_common_rounded"
+    android:paddingHorizontal="20dp"
+    android:paddingTop="36dp"
+    android:paddingBottom="24dp">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textAppearance="@style/Pretendard.18"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="방탈출을 종료하시겠습니까?" />
+
+    <TextView
+        android:id="@+id/tv_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:gravity="center"
+        android:textAppearance="@style/Pretendard.16"
+        android:textColor="@color/Gray01"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_title"
+        tools:text="종료하시면 모든 기록은 초기화됩니다." />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_negative"
+        style="@style/SmallButton.Dialog.Negative"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_positive"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_message"
+        tools:text="아니오" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_positive"
+        style="@style/SmallButton.Dialog"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_negative"
+        app:layout_constraintTop_toBottomOf="@id/tv_message"
+        tools:text="예" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -50,6 +50,23 @@
             android:defaultValue="0L"
             app:argType="long" />
     </fragment>
+    <dialog
+        android:id="@+id/nrTwoButtonDialog"
+        android:name="com.nextroom.nextroom.presentation.common.NRTwoButtonDialog"
+        tools:layout="@layout/dialog_fragment_nr_two_button">
+
+        <argument
+            android:name="nrTwoButtonArgument"
+            app:argType="com.nextroom.nextroom.presentation.common.NRTwoButtonDialog$NRTwoButtonArgument" />
+    </dialog>
+    <action
+        android:id="@+id/action_global_nrTwoButtonDialog"
+        app:destination="@id/nrTwoButtonDialog">
+        <argument
+
+            android:name="nrTwoButtonArgument"
+            app:argType="com.nextroom.nextroom.presentation.common.NRTwoButtonDialog$NRTwoButtonArgument" />
+    </action>
     <fragment
         android:id="@+id/verifyFragment"
         android:name="com.nextroom.nextroom.presentation.ui.verity.VerifyFragment"


### PR DESCRIPTION
- 기존에 만든 NRDialog 대신 Navigation 사용하는 방식으로 변경했습니다
- 앞으로 다이얼로그가 여러 형태로 만들어질 수 있을것을 생각해서 baseDialogFragment를 만들었습니다.
- 슬랙에 리포트했던 첫번째 두번째 버그는 더이상 재현되지 않습니다.
  - [슬랙 링크](https://slack-jor1187.slack.com/archives/C05FQN7N8CD/p1713201626370719)
- 세번째 버그는 여전히 재현되는데 다이얼로그랑 별개인듯 합니다. GameFragment의 onViewCreated가 2번 중복호출 되는것으로 봐서 이거랑 관련있는 듯 한데 아직 자세히는 확인해보지 않았음! (다른 티켓에서 해결하는 게 나을듯)
- NRDialog는 명범이가 이 PR 없다고 생각이 들면 삭제 커밋 올릴게용