### PR TITLE
#85 feat: 탈퇴 기능 추가

### DIFF
--- a/data/src/main/java/com/nextroom/nextroom/data/datasource/UserDataSource.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/datasource/UserDataSource.kt
@@ -1,0 +1,14 @@
+package com.nextroom.nextroom.data.datasource
+
+import com.nextroom.nextroom.data.network.ApiService
+import com.nextroom.nextroom.domain.model.Result
+import javax.inject.Inject
+
+/**
+ * 로그인 한 사용자의 정보와 관련된 DataSource
+ */
+class UserDataSource @Inject constructor(
+    private val apiService: ApiService,
+) {
+    suspend fun resign(): Result<Unit> = apiService.resign()
+}

--- a/data/src/main/java/com/nextroom/nextroom/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/di/RepositoryModule.kt
@@ -13,6 +13,7 @@ import com.nextroom.nextroom.data.datasource.SubscriptionDataSource
 import com.nextroom.nextroom.data.datasource.ThemeLocalDataSource
 import com.nextroom.nextroom.data.datasource.ThemeRemoteDataSource
 import com.nextroom.nextroom.data.datasource.TokenDataSource
+import com.nextroom.nextroom.data.datasource.UserDataSource
 import com.nextroom.nextroom.data.db.GameStateDao
 import com.nextroom.nextroom.data.db.HintDao
 import com.nextroom.nextroom.data.db.ThemeDao
@@ -110,10 +111,17 @@ object RepositoryModule {
     @Provides
     fun provideAdminRepository(
         authDataSource: AuthDataSource,
+        userDataSource: UserDataSource,
         settingDataSource: SettingDataSource,
         tokenDataSource: TokenDataSource,
         subscriptionDataSource: SubscriptionDataSource,
-    ): AdminRepository = AdminRepositoryImpl(authDataSource, settingDataSource, tokenDataSource, subscriptionDataSource)
+    ): AdminRepository = AdminRepositoryImpl(
+        authDataSource = authDataSource,
+        userDataSource = userDataSource,
+        settingDataSource = settingDataSource,
+        tokenDataSource = tokenDataSource,
+        subscriptionDataSource = subscriptionDataSource,
+    )
 
     @Singleton
     @Provides
@@ -121,6 +129,11 @@ object RepositoryModule {
         @ApplicationContext context: Context,
         @Named("defaultApiService") apiSource: ApiService,
     ): AuthDataSource = AuthDataSource(context, apiSource)
+
+    @Provides
+    fun provideUserDataSource(
+        apiService: ApiService,
+    ): UserDataSource = UserDataSource(apiService)
 
     @Singleton
     @Provides

--- a/data/src/main/java/com/nextroom/nextroom/data/network/ApiService.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/network/ApiService.kt
@@ -15,6 +15,7 @@ import com.nextroom.nextroom.data.network.response.UserSubscriptionStatusDto
 import com.nextroom.nextroom.domain.model.Result
 import com.nextroom.nextroom.domain.request.TokenRefreshRequest
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
@@ -23,6 +24,9 @@ interface ApiService {
 
     @POST("api/v1/auth/login")
     suspend fun login(@Body loginRequest: LoginRequest): Result<BaseResponse<LoginDto>>
+
+    @DELETE("api/v1/auth/unregister")
+    suspend fun resign(): Result<Unit>
 
     @POST("api/v1/auth/reissue")
     suspend fun refreshToken(@Body refreshRequest: TokenRefreshRequest): Result<BaseResponse<TokenDto>>

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/AdminRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/AdminRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.nextroom.nextroom.data.datasource.AuthDataSource
 import com.nextroom.nextroom.data.datasource.SettingDataSource
 import com.nextroom.nextroom.data.datasource.SubscriptionDataSource
 import com.nextroom.nextroom.data.datasource.TokenDataSource
+import com.nextroom.nextroom.data.datasource.UserDataSource
 import com.nextroom.nextroom.domain.model.LoginInfo
 import com.nextroom.nextroom.domain.model.Result
 import com.nextroom.nextroom.domain.model.UserSubscribeStatus
@@ -15,6 +16,7 @@ import javax.inject.Inject
 
 class AdminRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
+    private val userDataSource: UserDataSource,
     private val settingDataSource: SettingDataSource,
     private val tokenDataSource: TokenDataSource,
     private val subscriptionDataSource: SubscriptionDataSource,
@@ -33,6 +35,12 @@ class AdminRepositoryImpl @Inject constructor(
 
     override suspend fun logout() {
         authDataSource.logout()
+    }
+
+    override suspend fun resign(): Result<Unit> {
+        return userDataSource.resign().onSuccess {
+            logout()
+        }
     }
 
     override suspend fun verifyAdminCode(code: String): Boolean {

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/AdminRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/AdminRepository.kt
@@ -16,6 +16,7 @@ interface AdminRepository {
      * */
     suspend fun login(adminCode: String, password: String): Result<LoginInfo>
     suspend fun logout()
+    suspend fun resign(): Result<Unit>
     suspend fun verifyAdminCode(code: String): Boolean
     suspend fun getUserSubscribeStatus(): Result<UserSubscribeStatus>
     suspend fun getUserSubscribe(): Result<UserSubscription>

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainEvent.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainEvent.kt
@@ -4,4 +4,5 @@ sealed interface AdminMainEvent {
     data object NetworkError : AdminMainEvent
     data object UnknownError : AdminMainEvent
     data class ClientError(val message: String) : AdminMainEvent
+    data object OnResign : AdminMainEvent
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
@@ -78,6 +78,14 @@ class AdminMainViewModel @Inject constructor(
         viewModelScope.launch { adminRepository.logout() }
     }
 
+    fun resign() = intent {
+        viewModelScope.launch {
+            adminRepository.resign().onSuccess {
+                postSideEffect(AdminMainEvent.OnResign)
+            }
+        }
+    }
+
     fun loadData() = intent {
         reduce { state.copy(loading = true) }
         /*adminRepository.getUserSubscribeStatus().suspendOnSuccess {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/adminmain/AdminMainViewModel.kt
@@ -82,6 +82,8 @@ class AdminMainViewModel @Inject constructor(
         viewModelScope.launch {
             adminRepository.resign().onSuccess {
                 postSideEffect(AdminMainEvent.OnResign)
+            }.onFailure {
+                postSideEffect(AdminMainEvent.UnknownError)
             }
         }
     }

--- a/presentation/src/main/res/layout/fragment_admin_main.xml
+++ b/presentation/src/main/res/layout/fragment_admin_main.xml
@@ -27,51 +27,51 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
-<!-- 결제 관련 -->
-<!--            <TextView-->
-<!--                android:id="@+id/tv_purchase_ticket_button"-->
-<!--                style="@style/Pretendard.14.SemiBold"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_marginEnd="16dp"-->
-<!--                android:background="@drawable/bg_secondary_button"-->
-<!--                android:paddingHorizontal="16dp"-->
-<!--                android:paddingVertical="6dp"-->
-<!--                android:text="@string/purchase_ticket"-->
-<!--                android:textColor="@color/White"-->
-<!--                android:visibility="gone"-->
-<!--                app:layout_constraintBottom_toBottomOf="@id/iv_my_button"-->
-<!--                app:layout_constraintEnd_toStartOf="@id/iv_my_button"-->
-<!--                app:layout_constraintTop_toTopOf="@id/iv_my_button"-->
-<!--                tools:visibility="visible" />-->
 
-<!--            <TextView-->
-<!--                android:id="@+id/tv_logout_button"-->
-<!--                style="@style/Pretendard.14.SemiBold"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_marginEnd="16dp"-->
-<!--                android:background="@drawable/bg_secondary_button"-->
-<!--                android:paddingHorizontal="16dp"-->
-<!--                android:paddingVertical="6dp"-->
-<!--                android:text="@string/logout_button"-->
-<!--                android:textColor="@color/White"-->
-<!--                app:layout_constraintBottom_toBottomOf="@id/iv_my_button"-->
-<!--                app:layout_constraintEnd_toStartOf="@id/iv_my_button"-->
-<!--                app:layout_constraintTop_toTopOf="@id/iv_my_button"-->
-<!--                tools:visibility="visible" />-->
+            <TextView
+                android:id="@+id/tv_resign_button"
+                style="@style/Pretendard.14.SemiBold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                android:background="@drawable/bg_secondary_button"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="6dp"
+                android:text="@string/resign"
+                android:textColor="@color/White"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-<!--            <ImageView-->
-<!--                android:id="@+id/iv_my_button"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_marginTop="12dp"-->
-<!--                android:layout_marginEnd="20dp"-->
-<!--                android:contentDescription="@string/mypage_button_description"-->
-<!--                android:src="@drawable/ic_my"-->
-<!--                android:visibility="gone"-->
-<!--                app:layout_constraintEnd_toEndOf="parent"-->
-<!--                app:layout_constraintTop_toTopOf="parent" />-->
+            <!-- 결제 관련 -->
+
+            <!--            <TextView-->
+            <!--                android:id="@+id/tv_logout_button"-->
+            <!--                style="@style/Pretendard.14.SemiBold"-->
+            <!--                android:layout_width="wrap_content"-->
+            <!--                android:layout_height="wrap_content"-->
+            <!--                android:layout_marginEnd="16dp"-->
+            <!--                android:background="@drawable/bg_secondary_button"-->
+            <!--                android:paddingHorizontal="16dp"-->
+            <!--                android:paddingVertical="6dp"-->
+            <!--                android:text="@string/logout_button"-->
+            <!--                android:textColor="@color/White"-->
+            <!--                app:layout_constraintBottom_toBottomOf="@id/iv_my_button"-->
+            <!--                app:layout_constraintEnd_toStartOf="@id/iv_my_button"-->
+            <!--                app:layout_constraintTop_toTopOf="@id/iv_my_button"-->
+            <!--                tools:visibility="visible" />-->
+
+            <!--            <ImageView-->
+            <!--                android:id="@+id/iv_my_button"-->
+            <!--                android:layout_width="wrap_content"-->
+            <!--                android:layout_height="wrap_content"-->
+            <!--                android:layout_marginTop="12dp"-->
+            <!--                android:layout_marginEnd="20dp"-->
+            <!--                android:contentDescription="@string/mypage_button_description"-->
+            <!--                android:src="@drawable/ic_my"-->
+            <!--                android:visibility="gone"-->
+            <!--                app:layout_constraintEnd_toEndOf="parent"-->
+            <!--                app:layout_constraintTop_toTopOf="parent" />-->
 
             <TextView
                 android:id="@+id/tv_shop_name_label"
@@ -83,7 +83,7 @@
                 android:text="@string/admin_main_shop_name_label"
                 android:textAppearance="@style/Pretendard.32"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/tv_shop_name"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -58,6 +58,10 @@
     <string name="logout_button">로그아웃</string>
     <string name="logout_button_description">로그아웃</string>
     <string name="update_button_description">테마 업데이트</string>
+    <string name="resign_dialog_title">탈퇴하시겠습니까?</string>
+    <string name="resign_dialog_message">계정을 삭제하면 회원님의 테마 정보는 즉시 삭제되며, 삭제된 정보는 복구할 수 없습니다. 정말 탈퇴하시겠습니까?</string>
+    <string name="resign">탈퇴</string>
+    <string name="resign_success_message">탈퇴가 완료되었습니다</string>
 
     <string name="game_main_exit_dialog">방탈출을 종료하시겠습니까?</string>
     <string name="game_main_exit_dialog_message">종료하시면 모든 기록은 초기화됩니다.</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="link_privacy_policy">https://basalt-cathedral-c81.notion.site/fbb1f04ae70d473380e64d12ed013df8?pvs=4</string>
 
     <string name="error_network">네트워크 연결상태를 확인해주세요</string>
-    <string name="error_something">알 수 없는 문제가 발생했습니다. 잠시 후 다시 시도해주세요</string>
+    <string name="error_something">일시적인 오류입니다. 관리자에게 문의해 주세요.</string>
 
     <string name="sign_up">회원가입</string>
 


### PR DESCRIPTION
## 작업 내용

- 탈퇴 기능 구현
- 탈퇴 버튼 누르면 덜컥 탈퇴시켜버리기는 뭐해서 (잘못 누를 수도 있으니) 다이얼로그 띄우는 방향으로 작업
- 탈퇴 성공하면 토스트 메시지 띄움
- DataSource 어떤 거 쓸까 고민하다가 `UserDataSource` 새로 만듦. `AuthDataSource`에서 사용하는 `ApiService`는 헤더에 토큰 정보가 없어서 사용 불가. 추후에 프로필 관리 기능이 들어온다면 `UserDataSource`에 기능이 추가될 가능성이 높음.

---

서버 API 작업 완료되면 테스트 후 ready to review 로 전환 예정
