### PR TITLE
NR-104 새로운 Base 파일 구현

### DIFF
--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/base/BaseViewModelFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/base/BaseViewModelFragment.kt
@@ -1,0 +1,25 @@
+package com.nextroom.nextroom.presentation.base
+
+import androidx.viewbinding.ViewBinding
+import com.nextroom.nextroom.presentation.R
+import com.nextroom.nextroom.presentation.extension.repeatOnStarted
+import com.nextroom.nextroom.presentation.extension.toast
+import kotlinx.coroutines.launch
+
+abstract class BaseViewModelFragment<VB : ViewBinding, VM : NewBaseViewModel>(private val inflate: Inflate<VB>) :
+    NewBaseFragment<VB>(inflate) {
+    abstract val viewModel: VM
+
+    override fun initObserve() {
+        super.initObserve()
+
+        viewLifecycleOwner.repeatOnStarted {
+            launch {
+                viewModel.errorFlow.collect {
+                    // TODO: OneButtonDialog 제작 후 수정
+                    toast(R.string.error_something)
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/base/NewBaseFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/base/NewBaseFragment.kt
@@ -1,0 +1,54 @@
+package com.nextroom.nextroom.presentation.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.viewbinding.ViewBinding
+import com.nextroom.nextroom.presentation.extension.updateSystemPadding
+
+// 기존에 사용하던 BaseFragment를 다 걷어내면
+// 이 파일을 BaseFragment로 이름을 변경해 사용한다.
+abstract class NewBaseFragment<VB : ViewBinding>(private val inflate: Inflate<VB>) : Fragment() {
+    private var _binding: VB? = null
+    val binding: VB
+        get() = checkNotNull(_binding) { "binding is null" }
+
+    abstract val screenName: String
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        _binding = inflate.invoke(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        updateSystemPadding()
+
+        initListeners()
+        initObserve()
+        setFragmentResultListeners()
+        initViews()
+    }
+
+    open fun initListeners() {}
+    open fun initObserve() {}
+    open fun setFragmentResultListeners() {}
+    open fun initViews() {}
+
+    override fun onResume() {
+        super.onResume()
+
+        // TODO: 스크린 이벤트 남기기
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/base/NewBaseViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/base/NewBaseViewModel.kt
@@ -1,0 +1,38 @@
+package com.nextroom.nextroom.presentation.base
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nextroom.nextroom.presentation.BuildConfig
+import com.nextroom.nextroom.presentation.util.Logger
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.plus
+import kotlin.coroutines.cancellation.CancellationException
+
+// 기존에 사용하던 BaseViewModel을 다 걷어내면
+// 이 파일을 BaseViewModel로 이름을 변경해 사용한다.
+abstract class NewBaseViewModel : ViewModel() {
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        handleError(throwable)
+    }
+
+    protected val baseViewModelScope = viewModelScope + exceptionHandler
+
+    private val _errorFlow = MutableSharedFlow<Throwable>(extraBufferCapacity = 1)
+    val errorFlow = _errorFlow.asSharedFlow()
+
+    private fun handleError(throwable: Throwable) {
+        when (throwable) {
+            is CancellationException -> Unit
+            else -> {
+                if (!BuildConfig.DEBUG) {
+                    Logger.e("${this::class.simpleName} generated\n${throwable.message}")
+                }
+
+                _errorFlow.tryEmit(throwable)
+            }
+        }
+    }
+}


### PR DESCRIPTION
왜?
1. 개발자가 미처 처리하지 못한 exception 처리를 기본으로 해주는 BaseFragment, BaseViewModel 구조를 구현함
2. 기존 Base는 Orbit 라이브러리를 베이스로 하고 있어서 Base를 수정하면 Base를 상속받는 Fragment와 ViewModel의 로직과 구조를 전면 수정해야함. 작업 범위가 너무 커지고 PR의 목표에서 벗어나므로
이번 PR에서는 NewBaseXXX 파일을 만들고
순차적으로 모두 NewBase를 상속 받게 수정하는 것이 목표이다.
그렇게 모두 수정을 마치면 기존 Base 파일을 삭제하고 NewBase를 Base로 리네이밍 할 예정