### PR TITLE
NR-112 테마 업데이트에 성공 했을 때만 최근 업데이트를 갱신하도록 수정

### DIFF
--- a/data/src/main/java/com/nextroom/nextroom/data/datasource/ThemeLocalDataSource.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/datasource/ThemeLocalDataSource.kt
@@ -45,10 +45,6 @@ class ThemeLocalDataSource @Inject constructor(
         return themeDao.isThemeExist(themeId)
     }
 
-    suspend fun getUpdatedInfo(themeId: Int): Long {
-        return themeTimeDao.getTimeInfo(themeId)?.recentUpdated ?: 0L
-    }
-
     suspend fun updateUpdatedInfo(themeId: Int, updatedAt: Long) {
         if (themeTimeDao.isTimeInfoExists(themeId)) {
             themeTimeDao.updateRecentUpdated(themeId, updatedAt)

--- a/data/src/main/java/com/nextroom/nextroom/data/db/ThemeTimeDao.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/db/ThemeTimeDao.kt
@@ -16,9 +16,6 @@ interface ThemeTimeDao {
     @Query("UPDATE $THEME_TIME_TABLE_NAME SET recentUpdated = :updatedAt WHERE themeId = :themeId")
     suspend fun updateRecentUpdated(themeId: Int, updatedAt: Long)
 
-    @Query("SELECT * FROM $THEME_TIME_TABLE_NAME WHERE themeId = :themeId")
-    suspend fun getTimeInfo(themeId: Int): ThemeTimeEntity?
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTimeInfo(vararg themeTimeEntity: ThemeTimeEntity)
 

--- a/data/src/main/java/com/nextroom/nextroom/data/repository/ThemeRepositoryImpl.kt
+++ b/data/src/main/java/com/nextroom/nextroom/data/repository/ThemeRepositoryImpl.kt
@@ -56,10 +56,6 @@ class ThemeRepositoryImpl @Inject constructor(
         return themeLocalDataSource.getTheme(latestThemeId)
     }
 
-    override suspend fun getUpdatedInfo(themeId: Int): Long {
-        return themeLocalDataSource.getUpdatedInfo(themeId)
-    }
-
     override suspend fun activateThemeBackgroundImage(activeThemeIdList: List<Int>, deActiveThemeIdList: List<Int>): Result<Unit> {
         return themeRemoteDateSource.putActiveThemeBackgroundImage(ThemeBackgroundActivationId(activeThemeIdList, deActiveThemeIdList))
     }

--- a/domain/src/main/java/com/nextroom/nextroom/domain/repository/ThemeRepository.kt
+++ b/domain/src/main/java/com/nextroom/nextroom/domain/repository/ThemeRepository.kt
@@ -10,7 +10,6 @@ interface ThemeRepository {
     suspend fun upsertTheme(themeInfo: ThemeInfo)
     suspend fun updateLatestTheme(themeId: Int) // 최근 플레이 한 테마 갱신
     suspend fun getLatestTheme(): Flow<ThemeInfo> // 최근 플레이 한 테마
-    suspend fun getUpdatedInfo(themeId: Int): Long // 최근 업데이트 날짜 (Long)
     suspend fun activateThemeBackgroundImage(activeThemeIdList: List<Int>, deActiveThemeIdList: List<Int>): Result<Unit>
     suspend fun getThemeById(id: Int): ThemeInfo
 }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/model/ThemeInfoPresentation.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/model/ThemeInfoPresentation.kt
@@ -53,14 +53,13 @@ fun ThemeInfoPresentation.toDomain(themeImageCustomInfo: ThemeInfoPresentation.T
     )
 }
 
-fun ThemeInfo.toPresentation(recentUpdated: Long): ThemeInfoPresentation {
+fun ThemeInfo.toPresentation(): ThemeInfoPresentation {
     return ThemeInfoPresentation(
         id = id,
         title = title,
         timeLimit = timeLimitInMinute,
         hintLimit = hintLimit,
         hints = hints,
-        recentUpdated = recentUpdated,
         useTimerUrl = useTimerUrl,
         themeImageUrl = themeImageUrl,
         themeImageCustomInfo = themeImageCustomInfo?.toPresentation()

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/background_custom/BackgroundCustomViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/background_custom/BackgroundCustomViewModel.kt
@@ -66,9 +66,8 @@ class BackgroundCustomViewModel @Inject constructor(
     fun onThemeImageClicked(theme: ThemeInfoPresentation) = intent {
         baseViewModelScope.launch {
             try {
-                val updatedAt = themeRepository.getUpdatedInfo(theme.id)
                 themeRepository.getThemeById(theme.id)
-                    .toPresentation(updatedAt)
+                    .toPresentation()
                     .let {
                         postSideEffect(BackgroundCustomEvent.ThemeImageClicked(it))
                     }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectFragment.kt
@@ -240,10 +240,16 @@ class ThemeSelectFragment :
         llEmptyThemeGuide.isVisible = state.themes.isEmpty()
         adapter.submitList(state.themes.map { it.toAdapterUI() })
         tvThemeCount.text = state.themes.size.toString()
-        tvLastUpdate.text = getString(
-            R.string.text_last_hint_update,
-            DateTimeUtil().longToDateString(System.currentTimeMillis(), pattern = "yyyy.MM.dd HH:mm")
-        )
+        if (state.recentUpdatedDate == null) {
+            getString(R.string.text_last_hint_update_fail)
+        } else {
+            getString(
+                R.string.text_last_hint_update,
+                DateTimeUtil().longToDateString(state.recentUpdatedDate, pattern = "yyyy.MM.dd HH:mm")
+            )
+        }.also {
+            tvLastUpdate.text = it
+        }
 
         if (state.opaqueLoading) {
             NRLoading.BackgroundType.BLACK

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectState.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectState.kt
@@ -12,4 +12,5 @@ data class ThemeSelectState(
     val themes: List<ThemeInfoPresentation> = emptyList(),
     val banners: List<Banner> = emptyList(),
     val currentBannerPosition: Int = 0,
+    val recentUpdatedDate: Long?,
 )

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectViewModel.kt
@@ -127,15 +127,12 @@ class ThemeSelectViewModel @Inject constructor(
     }
 
     private suspend fun getThemes() {
-        themeRepository.getThemes().onSuccess {
-            updateThemes(
-                it.map { themeInfo ->
-                    val updatedAt = themeRepository.getUpdatedInfo(themeInfo.id)
-                    themeInfo.toPresentation(updatedAt)
-                },
-            )
+        themeRepository.getThemes().onSuccess { themes ->
+            themes
+                .map { it.toPresentation() }
+                .also { updateThemes(it) }
 
-            it.forEach { themeInfo ->
+            themes.forEach { themeInfo ->
                 hintRepository.saveHints(themeInfo.id).onFailure(::handleError)
             }
             updateNetworkDisconnectedCount(0)

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectViewModel.kt
@@ -36,6 +36,7 @@ class ThemeSelectViewModel @Inject constructor(
         ThemeSelectState(
             opaqueLoading = true,
             loading = true,
+            recentUpdatedDate = null
         )
     )
 
@@ -149,7 +150,12 @@ class ThemeSelectViewModel @Inject constructor(
     }
 
     private fun updateThemes(themes: List<ThemeInfoPresentation>) = intent {
-        reduce { state.copy(themes = themes) }
+        reduce {
+            state.copy(
+                themes = themes,
+                recentUpdatedDate = System.currentTimeMillis(),
+            )
+        }
     }
 
     fun tryGameStart(themeId: Int) = intent {

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/theme_select/ThemeSelectViewModel.kt
@@ -123,7 +123,7 @@ class ThemeSelectViewModel @Inject constructor(
                 shownBackgroundCustomDialog = true
                 postSideEffect(ThemeSelectEvent.RecommendBackgroundCustom)
             }
-        }
+        }.onFailure(::handleError)
         reduce { state.copy(opaqueLoading = false, loading = false) }
     }
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="tv_theme">테마</string>
     <string name="text_background_setting">배경 설정</string>
     <string name="text_last_hint_update">최근 힌트 업데이트 %s</string>
+    <string name="text_last_hint_update_fail">최근 힌트 업데이트를 불러오지 못했습니다.</string>
     <string name="text_timer_background_custom">타이머 배경 설정</string>
     <string name="text_background_custom_info_1">PC에서 배경을 등록하면 힌트폰에서 확인할 수 있습니다.</string>
     <string name="text_background_custom_info_2">미리보기에서 이미지의 어두움와 위치를 조정할 수 있습니다.</string>


### PR DESCRIPTION
- 테마별로 가지고 있는 업데이트 날짜 필드 제거
- 테마별 업데이트 날짜 가져오는 함수 제거
  - 과거 정책이므로 더이상 불필요
- 테마 정보 업데이트 성공 유무와 상관없이 매번 갱신하던 업데이트 날짜 로직 수정. 성공했을때만 갱신한다.