### PR TITLE
NR-140 게임 복원시 argument exception 발생하는 이슈 수정

### DIFF
--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/MainActivity.kt
@@ -91,6 +91,9 @@ class MainActivity :
                     direction = NavGraphDirections.moveToTimerFragment(event.subscribeStatus),
                     navOptions = NavOptions.Builder()
                         .setLaunchSingleTop(true)
+                        // 프로세스 죽음으로 복원된 게임 내부 백스택(hint 등)을 정리하여
+                        // 뒤로가기 시 theme_select로 돌아가도록 한다.
+                        .setPopUpTo(R.id.theme_select_fragment, inclusive = false)
                         .build()
                 )
             }

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameSharedViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/main/GameSharedViewModel.kt
@@ -21,7 +21,8 @@ class GameSharedViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(
         GameSharedState(
-            subscribeStatus = TimerFragmentArgs.fromSavedStateHandle(savedStateHandle).subscribeStatus
+            subscribeStatus = savedStateHandle.get<SubscribeStatus>("subscribeStatus")
+                ?: SubscribeStatus.Default
         )
     )
     val state: StateFlow<GameSharedState> = _state.asStateFlow()

--- a/presentation/src/main/res/navigation/game_navigation.xml
+++ b/presentation/src/main/res/navigation/game_navigation.xml
@@ -5,6 +5,10 @@
     android:id="@+id/game_navigation"
     app:startDestination="@id/timer_fragment">
 
+    <argument
+        android:name="subscribeStatus"
+        app:argType="com.nextroom.nextroom.domain.model.SubscribeStatus" />
+
     <fragment
         android:id="@+id/timer_fragment"
         android:name="com.nextroom.nextroom.presentation.ui.main.TimerFragment"
@@ -20,9 +24,6 @@
             android:name="overflowTime"
             android:defaultValue="0L"
             app:argType="long" />
-        <argument
-            android:name="subscribeStatus"
-            app:argType="com.nextroom.nextroom.domain.model.SubscribeStatus" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
힌트화면이 떠있는 상태에서
프로세스에 의해 앱이 죽었을 때
GameSharedViewModel에서 타이머 화면의 arg에 접근하다가 크래시가 발생

navigaiton level에서 arg를 받도록 수정하고
게임 복원시 setPopUpTo를 설정하여 스택이 꼬이지 않게 수정하였음