### PR TITLE
NR-142 구독 상태때 등록한 이미지가 남아있는 경우 테마 수정 시도시 토스트를 띄운다.

### DIFF
--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/manage/hint/HintManageFragment.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/manage/hint/HintManageFragment.kt
@@ -72,6 +72,7 @@ class HintManageFragment : ComposeBaseViewModelFragment<HintManageViewModel>() {
                             is HintManageEvent.RequestDeleteHint -> showDeleteConfirmDialog(event.hint)
                             is HintManageEvent.HintSaved -> snackbar(R.string.hint_manage_save_success)
                             is HintManageEvent.HintDeleted -> snackbar(R.string.hint_manage_delete_success)
+                            is HintManageEvent.SaveBlockedDueToImages -> toast(R.string.hint_save_blocked_due_to_images)
                             is HintManageEvent.ImageUploadFailed -> {
                                 when (event.reason) {
                                     HintManageEvent.ImageUploadFailed.Reason.INVALID_FORMAT -> R.string.image_invalid_format

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/manage/hint/HintManageState.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/manage/hint/HintManageState.kt
@@ -57,6 +57,7 @@ sealed interface HintManageEvent {
     data class RequestDeleteHint(val hint: Hint) : HintManageEvent
     data object HintSaved : HintManageEvent
     data object HintDeleted : HintManageEvent
+    data object SaveBlockedDueToImages : HintManageEvent
     data class ImageUploadFailed(val reason: Reason) : HintManageEvent {
         enum class Reason {
             INVALID_FORMAT,

--- a/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/manage/hint/HintManageViewModel.kt
+++ b/presentation/src/main/java/com/nextroom/nextroom/presentation/ui/manage/hint/HintManageViewModel.kt
@@ -196,6 +196,15 @@ class HintManageViewModel @Inject constructor(
 
     fun saveHint() {
         val editData = _editData.value
+        if (editData.hintId != null &&
+            adminRepository.cachedSubscribeStatus != SubscribeStatus.Subscribed &&
+            (editData.hintImageUrls.isNotEmpty() || editData.answerImageUrls.isNotEmpty())
+        ) {
+            baseViewModelScope.launch {
+                _uiEvent.emit(HintManageEvent.SaveBlockedDueToImages)
+            }
+            return
+        }
         _sheetType.value = HintSheetType.None
         baseViewModelScope.launch {
             try {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -296,4 +296,5 @@
     <string name="image_invalid_size">이미지 크기는 10MB 이하여야 합니다</string>
     <string name="image_invalid_format">지원하지 않는 이미지 형식입니다</string>
     <string name="feature_for_subscriber">구독이 필요한 기능입니다.</string>
+    <string name="hint_save_blocked_due_to_images">구독이 만료되었습니다. 이미지를 삭제한 후 저장해 주세요.</string>
 </resources>


### PR DESCRIPTION
왜?
구독 상태때 등록한 이미지가 남아있는경우
테마 정보를 수정하려 시도할때 이미지 정보를 포함하여 서버에 post 요청을 보내기 때문에 구독 상태가 아니여서 api 요청을 실패한다.

이미지를 삭제하고 수정을 해야함을 사용자에게 안내하는 방향으로 수정한다.